### PR TITLE
Warn when the rootDir contains the node_modules directory

### DIFF
--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -23,10 +23,17 @@ var ghPages = require('gh-pages');
 var gitconfiglocal = require('gitconfiglocal');
 var gutil = require('gulp-util');
 
+var fs = require('fs');
+var path = require('path');
+
 module.exports = promisify(function(config, callback) {
   config = config || {};
 
   var rootDir = config.rootDir ? config.rootDir : '.';
+
+  if (fs.existsSync(path.join(rootDir, 'node_modules'))) {
+    gutil.log(gutil.colors.red('With the current value of the \'rootDir\' option, the entire node_modules directory is going to be deployed. Please make sure this is what you really want.'));
+  }
 
   if ('GH_TOKEN' in process.env) {
     // We're using a token to authenticate with GitHub, so we have to embed


### PR DESCRIPTION
While working on https://github.com/marco-c/tictactoe/, I was using the default value for the `rootDir` option.
This was causing the entire `node_modules` directory to be uploaded to `gh-pages`, but most of the files in `node_modules` weren't actually needed (at the time, actually, no one was needed).

So, I think we should warn the user when oghliner is going to upload the entire `node_modules` directory.

In the future, we should probably allow the user to specify a file whitelist/blocklist.
