### PR TITLE
Only ignore errors while removing the offline-worker.js file if it's …

### DIFF
--- a/lib/offline.js
+++ b/lib/offline.js
@@ -42,13 +42,11 @@ module.exports = promisify(function(config, callback) {
   // it in the list of files to cache.
   try {
     fs.unlinkSync(path.join(rootDir, 'offline-worker.js'));
-  } catch(ex) {
-    // XXX Only ignore the error if it's a 'file not found' error, i.e.:
-    // { [Error: ENOENT, no such file or directory 'dist/offline-worker.js']
-    //    errno: -2,
-    //    code: 'ENOENT',
-    //    path: 'dist/offline-worker.js',
-    //    syscall: 'unlink' }
+  } catch (ex) {
+    // Only ignore the error if it's a 'file not found' error.
+    if (!ex.code || ex.code !== 'ENOENT') {
+      throw ex;
+    }
   }
 
   swPrecache.write(path.join(rootDir, 'offline-worker.js'), {


### PR DESCRIPTION
…a 'file not found' error
