### PR TITLE
Implement `integrate` function/CLI command to simplify integrating offline-manager.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,16 +71,10 @@ The *oghliner.offline* task takes a *config* object and a *callback*. The proper
 
 - *rootDir*: the directory to deploy (default: `./`).
 
-Finally, in order for offline-worker.js to be evaluated, you need to load the offline manager script in your app by copying it to the location of your other scripts:
+Finally, in order for offline-worker.js to be evaluated, you need to load the offline manager script in your app by copying it to the location of your other scripts. To do this, use the *integrate* command (or *ogliner.integrate* function):
 
 ```bash
-cp node_modules/oghliner/app/scripts/offline-manager.js path/to/your/scripts/
-```
-
-And then loading it into your app's HTML file(s):
-
-```html
-<script src="path/to/your/scripts/offline-manager.js"></script>
+oghliner integrate path/to/your/scripts/
 ```
 
 Automatic Deployment Via Travis

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The *oghliner.offline* task takes a *config* object and a *callback*. The proper
 
 - *rootDir*: the directory to deploy (default: `./`).
 
-Finally, in order for offline-worker.js to be evaluated, you need to load the offline manager script in your app by copying it to the location of your other scripts. To do this, use the *integrate* command (or *ogliner.integrate* function):
+Finally, in order for offline-worker.js to be evaluated, you need to load the offline manager script in your app by copying it to the location of your other scripts. To do this, use the *integrate* command (or *oghliner.integrate* function):
 
 ```bash
 oghliner integrate path/to/your/scripts/

--- a/cli.js
+++ b/cli.js
@@ -30,6 +30,7 @@ var configure = require('./lib/configure');
 var deploy = require('./lib/deploy');
 var offline = require('./lib/offline');
 var bootstrap = require('./lib/bootstrap');
+var integrate = require('./lib/integrate');
 
 program
   .version(packageJson.version);
@@ -89,6 +90,18 @@ program
       console.error(err);
     });
   });
+
+  program
+    .command('integrate [dir]')
+    .description('integrate the offline-manager.js script into your app')
+    .action(function(dir) {
+      integrate({
+        dir: dir,
+      })
+      .catch(function(err) {
+        console.error(err);
+      });
+    });
 
 program.parse(process.argv);
 

--- a/lib/integrate.js
+++ b/lib/integrate.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2015 Mozilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+// Import this first so we can use it to wrap other modules we import.
+var promisify = require("promisify-node");
+
+var fs = require('fs');
+var path = require('path');
+var gutil = require('gulp-util');
+
+module.exports = promisify(function(config, callback) {
+  var dir = config.dir || './';
+
+  var offlineManagerPath = path.join(path.dirname(__dirname), 'app', 'scripts', 'offline-manager.js');
+  if (!fs.existsSync(offlineManagerPath)) {
+    throw new Error('offline-manager.js doesn\'t exist');
+  }
+
+  var dest = path.join(dir, 'offline-manager.js');
+
+  var srcStream = fs.createReadStream(offlineManagerPath);
+  srcStream.pipe(fs.createWriteStream(dest));
+  srcStream.on('end', callback);
+});

--- a/lib/integrate.js
+++ b/lib/integrate.js
@@ -35,5 +35,13 @@ module.exports = promisify(function(config, callback) {
 
   var srcStream = fs.createReadStream(offlineManagerPath);
   srcStream.pipe(fs.createWriteStream(dest));
-  srcStream.on('end', callback);
+  srcStream.on('end', function() {
+    gutil.log(gutil.colors.blue(
+      'Your app needs to load the script offline-manager.js in order to register the service ' +
+      'worker that offlines your app. To load the script, add this line to your app\'s HTML ' +
+      'page(s)/template(s): <script src="' + path.join(dir, 'offline-manager.js') + '"></script>'
+    ));
+
+    callback();
+  });
 });

--- a/lib/integrate.js
+++ b/lib/integrate.js
@@ -40,10 +40,11 @@ module.exports = promisify(function(config, callback) {
   var srcStream = fs.createReadStream(offlineManagerPath);
   srcStream.pipe(fs.createWriteStream(dest));
   srcStream.on('end', function() {
-    gutil.log(gutil.colors.blue(
-      'Your app needs to load the script offline-manager.js in order to register the service ' +
-      'worker that offlines your app. To load the script, add this line to your app\'s HTML ' +
-      'page(s)/template(s): <script src="' + path.join(dir, 'offline-manager.js') + '"></script>'
+    console.log(gutil.colors.blue(
+      'Your app needs to load the script offline-manager.js in order to register the service\n' +
+      'worker that offlines your app. To load the script, add this line to your app\'s HTML\n' +
+      'page(s)/template(s):\n\n' +
+      '\t<script src="' + path.join(dir, 'offline-manager.js') + '"></script>'
     ));
 
     callback();

--- a/lib/integrate.js
+++ b/lib/integrate.js
@@ -26,6 +26,10 @@ var gutil = require('gulp-util');
 module.exports = promisify(function(config, callback) {
   var dir = config.dir || './';
 
+  if (!fs.existsSync(dir)) {
+    throw new Error('The directory you\'ve specified doesn\'t exist');
+  }
+
   var offlineManagerPath = path.join(path.dirname(__dirname), 'app', 'scripts', 'offline-manager.js');
   if (!fs.existsSync(offlineManagerPath)) {
     throw new Error('offline-manager.js doesn\'t exist');

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "lib/deploy.js",
     "lib/offline.js",
     "lib/bootstrap.js",
+    "lib/integrate.js",
     "templates/"
   ],
   "dependencies": {


### PR DESCRIPTION
This adds an `integrate` command as described in #25.
I haven't implemented the "add script automatically" part yet, I will do it in a follow-up.
