### PR TITLE
Add unit test for 'deploy'

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,8 +56,10 @@
   },
   "devDependencies": {
     "chai": "^3.3.0",
+    "fs-extra": "^0.24.0",
     "gulp-mocha": "^2.1.3",
-    "mocha": "^2.3.3"
+    "mocha": "^2.3.3",
+    "simple-git": "^1.11.0"
   },
   "engines": {
     "node": ">= 0.12"

--- a/test/testDeploy.js
+++ b/test/testDeploy.js
@@ -23,13 +23,65 @@ describe('Deploy', function() {
                       .addRemote('origin', path.join(process.cwd(), 'tmp'), function() {
         process.chdir('tmp');
 
-        return deploy({}).then(function() {
+        return deploy({
+          cloneDir: '.gh-pages-cache',
+        }).then(function() {
           process.chdir('..');
 
           return simpleGit.checkout('gh-pages').log(function(err, log) {
-            assert.equal(log.total, 1, '1 commit');
-            assert.equal(fs.readFileSync('tmp/file', 'utf8'), 'data');
-            finish();
+            try {
+              assert.equal(log.total, 1, '1 commit');
+              assert.equal(fs.readFileSync('tmp/file', 'utf8'), 'data');
+              finish();
+            } catch (e) {
+              finish(e);
+            }
+          });
+        }, function() {
+          process.chdir('..');
+          assert(false, 'Deploy\'s promise should be resolved');
+        }).catch(finish);
+      });
+    });
+  });
+
+  it('should update the gh-pages branch in the origin repo and publish files to it', function(done) {
+    fs.mkdirSync('tmp');
+
+    function finish(err) {
+      fse.removeSync('tmp');
+      done(err);
+    }
+
+    var simpleGit = require('simple-git')('tmp');
+
+    simpleGit.init(function() {
+      fs.writeFileSync('tmp/file1', 'data1');
+      fs.writeFileSync('tmp/file2', 'data2')
+
+      return simpleGit.add('file1')
+                      .commit('Initial commit')
+                      .addRemote('origin', path.join(process.cwd(), 'tmp'))
+                      .checkoutLocalBranch('gh-pages')
+                      .add('file2')
+                      .commit('Commit in gh-pages')
+                      .checkout('master', function() {
+        process.chdir('tmp');
+
+        return deploy({
+          cloneDir: '.gh-pages-cache',
+        }).then(function() {
+          process.chdir('..');
+
+          return simpleGit.checkout('gh-pages').log(function(err, log) {
+            try {
+              assert.equal(log.total, 3, '3 commits');
+              assert.equal(fs.readFileSync('tmp/file1', 'utf8'), 'data1');
+              assert(!fs.existsSync('tmp/file2'), 'Old files are removed when deploying');
+              finish();
+            } catch (e) {
+              finish(e);
+            }
           });
         }, function() {
           process.chdir('..');

--- a/test/testDeploy.js
+++ b/test/testDeploy.js
@@ -1,0 +1,41 @@
+var assert = require('assert');
+var fs = require('fs');
+var fse = require('fs-extra');
+var path = require('path');
+var deploy = require('../lib/deploy');
+
+describe('Deploy', function() {
+  it('should create a gh-pages branch in the origin repo and publish files to it', function(done) {
+    fs.mkdirSync('tmp');
+
+    function finish(err) {
+      fse.removeSync('tmp');
+      done(err);
+    }
+
+    var simpleGit = require('simple-git')('tmp');
+
+    simpleGit.init(function() {
+      fs.writeFileSync('tmp/file', 'data');
+
+      return simpleGit.add('file')
+                      .commit('Initial commit')
+                      .addRemote('origin', path.join(process.cwd(), 'tmp'), function() {
+        process.chdir('tmp');
+
+        return deploy({}).then(function() {
+          process.chdir('..');
+
+          return simpleGit.checkout('gh-pages').log(function(err, log) {
+            assert.equal(log.total, 1, '1 commit');
+            assert.equal(fs.readFileSync('tmp/file', 'utf8'), 'data');
+            finish();
+          });
+        }, function() {
+          process.chdir('..');
+          assert(false, 'Deploy\'s promise should be resolved');
+        }).catch(finish);
+      });
+    });
+  });
+});


### PR DESCRIPTION
This is the first `deploy` unit tests, we can add more to test other conditions, but they should be simple to write after this first one.

The test creates a new git repository, adds a file and commits it, then sets itself as its 'origin' repository.
At this point, `deploy` is called, which creates the gh-pages branch and commits the same file.
