### PR TITLE
Revert "Use gh-pages 'silent' option instead of not specifying a logger"

### DIFF
--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -40,7 +40,6 @@ module.exports = promisify(function(config, callback) {
     ghPagesConfig.clone = cloneDir;
   }
 
-  ghPagesConfig.logger = gutil.log;
   ghPagesConfig.commitMessage = commitMessage;
 
   if (fs.existsSync(path.join(rootDir, 'node_modules'))) {
@@ -49,7 +48,7 @@ module.exports = promisify(function(config, callback) {
 
   if ('GH_TOKEN' in process.env) {
     // We can't log here because it would leak the GitHub token on Travis.
-    ghPagesConfig.silent = true;
+    // ghPagesConfig.logger = gutil.log;
 
     // We're using a token to authenticate with GitHub, so we have to embed
     // the token into the repo URL (if it isn't already there).
@@ -74,7 +73,8 @@ module.exports = promisify(function(config, callback) {
     });
   } else {
     // We aren't using a token to authenticate with GitHub, so we don't have to
-    // alter the repo URL.
+    // alter the repo URL.  And we can log, since we won't leak a GitHub token.
+    ghPagesConfig.logger = gutil.log;
     ghPages.publish(rootDir, ghPagesConfig, callback);
   }
 });

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -48,6 +48,8 @@ module.exports = promisify(function(config, callback) {
 
   if ('GH_TOKEN' in process.env) {
     // We can't log here because it would leak the GitHub token on Travis.
+    // We can't use the gh-pages silent option because it makes error messages
+    // less informative (https://github.com/mozilla/oghliner/pull/58#issuecomment-147550610).
     // ghPagesConfig.logger = gutil.log;
 
     // We're using a token to authenticate with GitHub, so we have to embed


### PR DESCRIPTION
Reverts mozilla/oghliner#58
