### PR TITLE
Add basic test for bootstrap.

### DIFF
--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -23,6 +23,8 @@ var install = require('gulp-install');
 var rename = require("gulp-rename");
 var inquirer = require('inquirer');
 var gitconfiglocal = require('gitconfiglocal');
+var through2 = require('through2');
+var util = require('gulp-util');
 
 function prompt(questions) {
   // inquirer doesn't follow the node style callback so we can't use promisify
@@ -49,7 +51,7 @@ function gitUrl(dir) {
 }
 
 function templateConfigPrompt(defaultConfig) {
-  console.log("The current template configuation is:")
+  console.log("The current template configuration is:")
   console.log(templateConfigToString(defaultConfig));
 
   return prompt([ { type: "confirm", name: "fillInConfig", message: "Would you like to change any of the above configuration values?"}]).then(function(answers) {
@@ -85,6 +87,16 @@ function templateConfigPrompt(defaultConfig) {
   });
 }
 
+function templateConfigOption(defaultConfig, config) {
+  for (var key in config) {
+    if (typeof defaultConfig[key] === "undefined") {
+      throw new Error("Unrecognized template option: " + key);
+    }
+    defaultConfig[key] = config[key];
+  }
+  return defaultConfig;
+}
+
 function templateConfigToString(config) {
   var out = [];
   for (var key in config) {
@@ -113,12 +125,24 @@ function getDefaultTemplateConfig(dir) {
   })
 }
 
+function sink() {
+  return through2.obj(function (file, enc, callback) {
+    callback();
+  });
+}
+
 module.exports = function(config) {
   config = config || {};
+  config.npmInstall = 'npmInstall' in config ? config.npmInstall : true;
 
   var rootDir = config.rootDir ? config.rootDir : '.';
   return getDefaultTemplateConfig(rootDir)
-    .then(templateConfigPrompt)
+    .then(function(defaultConfig) {
+      if (config.template) {
+        return templateConfigOption(defaultConfig, config.template);
+      }
+      return templateConfigPrompt(defaultConfig);
+    })
     .then(function(templateConfig) {
       return new Promise(function(resolve, reject) {
         var stream = gulp.src([__dirname + '/../templates/**'])
@@ -131,7 +155,8 @@ module.exports = function(config) {
           .pipe(template(templateConfig))
           .pipe(conflict(rootDir))
           .pipe(gulp.dest(rootDir))
-          .pipe(install());
+          .pipe(config.npmInstall ? install() : util.noop())
+          .pipe(sink()); // Sink is required to trigger the finish event with install/noop.
         stream.on('finish', resolve);
         stream.on('error', reject);
       });

--- a/package.json
+++ b/package.json
@@ -57,9 +57,12 @@
   "devDependencies": {
     "chai": "^3.3.0",
     "fs-extra": "^0.24.0",
+    "glob": "^5.0.15",
     "gulp-mocha": "^2.1.3",
     "mocha": "^2.3.3",
-    "simple-git": "^1.11.0"
+    "simple-git": "^1.11.0",
+    "temp": "^0.8.3",
+    "through2": "2.0.0"
   },
   "engines": {
     "node": ">= 0.12"

--- a/test/testBootstrap.js
+++ b/test/testBootstrap.js
@@ -1,8 +1,49 @@
+var promisify = require('promisify-node');
 var expect = require('chai').expect;
+var childProcess = require('child_process');
+var temp = promisify(require('temp'));
+var bootstrap = require('../lib/bootstrap');
+var glob = require('glob');
+var fs = require('fs');
 
 describe('Bootstrap', function() {
-  it('should create files', function() {
-    // TODO write tests
-    expect(true).to.equal(true);
+  var appName = 'test-bootstrap'
+  var oldWd;
+  before(function() {
+    temp.track();
+    return temp.mkdir('pdfcreator').then(function(dirPath) {
+      oldWd = process.cwd();
+      process.chdir(dirPath);
+      childProcess.execSync('git init');
+      childProcess.execSync('git remote add upstream https://github.com/mozilla/oghliner.git');
+      return bootstrap({
+        template: {
+          name: appName
+        },
+        npmInstall: false,
+      });
+    });
+  });
+
+  it('should create files supporting files', function() {
+    expect(glob.sync('.gitignore').length).to.equal(1);
+    expect(glob.sync('package.json').length).to.equal(1);
+    expect(glob.sync('gulpfile.js').length).to.equal(1);
+  });
+
+  it('should create some temple app files', function() {
+    expect(glob.sync('**/*.html').length).to.above(0);
+    expect(glob.sync('**/*.css').length).to.above(0);;
+    expect(glob.sync('**/*.png').length).to.above(0);
+  });
+
+  it('should set the app name', function() {
+    var package = JSON.parse(fs.readFileSync('package.json'));
+    expect(package.name).to.equal(appName);
+  });
+
+  after(function() {
+    process.chdir(oldWd);
+    temp.cleanupSync();
   });
 });


### PR DESCRIPTION
I had some issues with the gulp-install not triggering a finish event, but that can be fixed with calling sink() at the end. However, I have install disabled for tests as it is slow and require network connectivity.

Fixes #36
