### PR TITLE
specify repo URL to gh-pages to fix Travis auto-deploy

### DIFF
--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -67,7 +67,7 @@ module.exports = promisify(function(config, callback) {
                     url.match(/^https:\/\/github.com\/([^/]+)\/([^.]+)\.git$/)) {
           url = 'https://' + process.env.GH_TOKEN + '@github.com/' + match[1] + '/' + match[2] + '.git';
         }
-
+        ghPagesConfig.repo = url;
         ghPages.publish(rootDir, ghPagesConfig, callback);
       } else {
         callback('repo has no origin url');


### PR DESCRIPTION
This should work, although I haven't tested it yet, since I can't do so easily.
