### PR TITLE
update oghliner and node requirements

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -364,12 +364,12 @@ module.exports = function() {
       if (err.code === 'ENOENT') {
         process.stdout.write('You don\'t have a .travis.yml file.  Creating one for you…\n');
         process.stdout.write('Setting "language" to "node_js"…\n');
-        process.stdout.write('Setting "node_js" to "[ "0.10" ]"…\n');
+        process.stdout.write('Setting "node_js" to "[ "0.12" ]"…\n');
         process.stdout.write('Setting "install" to "npm install"…\n');
         process.stdout.write('Setting "script" to "gulp"…\n');
         travisYml = {
           language: 'node_js',
-          node_js: [ '0.10' ],
+          node_js: [ '0.12' ],
           install: 'npm install',
           script: 'gulp',
         };

--- a/templates/package.json
+++ b/templates/package.json
@@ -10,6 +10,6 @@
   "dependencies": {
     "gulp": "^3.9.0",
     "gulp-connect": "^2.2.0",
-    "oghliner": "^0.7.0"
+    "oghliner": "^0.9.1"
   }
 }


### PR DESCRIPTION
This makes _configure_ write a .travis.yml file that requires Node 0.12. It also updates the _oghliner_ requirement in the template's package.json file to 0.9.1, which is the version I just pushed to npmjs.com that fixes the auto-deploy regression (#91, for 0.9.1; isn't it ironic!).
