### PR TITLE
Add other 'deploy' tests

### DIFF
--- a/test/testDeploy.js
+++ b/test/testDeploy.js
@@ -189,4 +189,30 @@ describe('Deploy', function() {
     process.env.GH_TOKEN = 'oghliner';
     return deployOutsideRepo('message');
   });
+
+  it('should succeed if there\'s a node_modules directory in the rootDir', function(done) {
+    var dir = temp.mkdirSync('oghliner');
+
+    var simpleGit = require('simple-git')(dir);
+
+    simpleGit.init(function() {
+      fs.writeFileSync(path.join(dir, 'file'), 'data');
+      fs.mkdirSync(path.join(dir, 'node_modules'));
+
+      return simpleGit.add('file')
+                      .commit('Initial commit')
+                      .addRemote('origin', dir, function() {
+        process.chdir(dir);
+
+        return deploy({
+          cloneDir: '.gh-pages-cache',
+        }).then(function() {
+          assert(true, 'Deploy\'s promise should be resolved');
+          done();
+        }, function() {
+          assert(false, 'Deploy\'s promise should be resolved');
+        }).catch(done);
+      });
+    });
+  });
 });

--- a/test/testDeploy.js
+++ b/test/testDeploy.js
@@ -128,4 +128,34 @@ describe('Deploy', function() {
   it('should try to publish with a different repo URL (SSH)', function(done) {
     deployDifferentRepoURL(done, 'git@github.com:mozilla/oghliner.git');
   });
+
+  function deployNoOriginRemote(done) {
+    var dir = temp.mkdirSync('oghliner');
+
+    var simpleGit = require('simple-git')(dir);
+
+    simpleGit.init(function() {
+      fs.writeFileSync(path.join(dir, 'file'), 'data');
+
+      return simpleGit.add('file')
+                      .commit('Initial commit', function() {
+        process.chdir(dir);
+
+        return deploy({
+          cloneDir: '.gh-pages-cache',
+        }).then(function() {
+          assert(false, 'Deploy\'s promise should be rejected');
+        }, function() {
+          assert(true, 'Deploy\'s promise should be rejected');
+        }).then(done, done);
+      });
+    });
+  }
+
+  it('should fail if there is no origin remote', deployNoOriginRemote);
+
+  it('should fail if there is no origin remote', function(done) {
+    process.env.GH_TOKEN = 'oghliner';
+    deployNoOriginRemote(done);
+  });
 });

--- a/test/testDeploy.js
+++ b/test/testDeploy.js
@@ -158,4 +158,35 @@ describe('Deploy', function() {
     process.env.GH_TOKEN = 'oghliner';
     deployNoOriginRemote(done);
   });
+
+  function deployOutsideRepo(message) {
+    var dir = temp.mkdirSync('oghliner');
+
+    process.chdir(dir);
+
+    return deploy({
+      cloneDir: '.gh-pages-cache',
+      message: message,
+    }).then(function() {
+      assert(false, 'Deploy\'s promise should be rejected');
+    }, function() {
+      assert(true, 'Deploy\'s promise should be rejected');
+    });
+  }
+
+  it('should fail if called outside of a git repository with no commit message', function() {
+    return deployOutsideRepo();
+  });
+  it('should fail if called outside of a git repository with commit message', function() {
+    return deployOutsideRepo('message');
+  });
+
+  it('should fail if called outside of a git repository (on Travis) with no commit message', function() {
+    process.env.GH_TOKEN = 'oghliner';
+    return deployOutsideRepo();
+  });
+  it('should fail if called outside of a git repository (on Travis) with commit message', function() {
+    process.env.GH_TOKEN = 'oghliner';
+    return deployOutsideRepo('message');
+  });
 });


### PR DESCRIPTION
This improves code coverage in lib/deploy.js:

|  | % Stmts | % Branch | % Funcs | % Lines | Uncovered Lines |
| --- | --- | --- | --- | --- | --: |
| _before_ | 61.76 | 28 | 50 | 61.76 | ... 68,70,71,73 |
| _after_ | 100 | 80 | 100 | 100 |  |
