### PR TITLE
Catch fatal error in the case that the repository has no commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ Invoke `gulp` to rebuild your app and regenerate the script that offlines it. In
 gulp && gulp deploy
 ```
 
+At least one commit to the repository is required for successful deploy.  The following could be used to commit the changes by Oghliner to the respository:
+
+```bash
+git add . && git commit -m "Initial version of app"
+```
+
 Using The Tool
 --------------
 

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -32,7 +32,19 @@ module.exports = promisify(function(config, callback) {
   var ghPagesConfig = {};
   var rootDir = config.rootDir ? config.rootDir : '.';
   var cloneDir = config.cloneDir ? config.cloneDir : null;
-  var commitMessage = config.message ? config.message : childProcess.execSync('git log --format=%B -n 1').toString().trim();
+
+  var commitMessage = config.message || (function() {
+    var spawn = childProcess.spawnSync('git', ['log', '--format=%B', '-n', '1']);
+    var errorText = spawn.stderr.toString().trim();
+
+    if (errorText) {
+      gutil.log('Fatal error from `git log`.  You must have one commit before deploying.');
+      throw new Error(errorText);
+    }
+    else {
+      return spawn.stdout.toString().trim();
+    }
+  })();
 
   gutil.log('Deploying "' + commitMessage + '"');
 


### PR DESCRIPTION
If you attempt to `deploy` on a repository with no commits, you receive a fatal error directly from `childProcess.execSync`.  This pull requests mentions that in documentation but also programmatically catches said error and provides a more elegant notification for the user.

First commit, be gentle.  :) 
