### PR TITLE
copy Tabzilla files directly to dist/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node_modules/
 dist/
 coverage/
-app/styles/tabzilla/

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -25,12 +25,14 @@ var oghliner = require('./index.js');
 
 gulp.task('default', ['build', 'offline']);
 
-gulp.task('build', ['build-tabzilla'], function(callback) {
+gulp.task('build', ['copy-files', 'build-tabzilla']);
+
+gulp.task('copy-files', function(callback) {
   return gulp.src('app/**').pipe(gulp.dest('dist'));
 });
 
-gulp.task('build-tabzilla', function() {
-  return gulp.src('node_modules/mozilla-tabzilla/**/*.{css,png}').pipe(gulp.dest('app/styles/tabzilla'));
+gulp.task('build-tabzilla', ['copy-files'], function() {
+  return gulp.src('node_modules/mozilla-tabzilla/**/*.{css,png}').pipe(gulp.dest('dist/styles/tabzilla'));
 });
 
 gulp.task('configure', oghliner.configure);


### PR DESCRIPTION
@darkwing What do you think about copying the Tabzilla files directly to the dist/ directory? Then we wouldn't have to .gitignore them, as the entire dist/ directory is .gitignored already. And old files would be less likely to stick around, since the dist/ directory is more likely to be blown away and recreated from scratch.

(Currently, old files aren't deleted from app/styles/tabzilla/, so if a Tabzilla update changes the files we copy, f.e. updating the name of an image file, then the old files will stick around in app/styles/tabzilla/. Copying directly to dist/ doesn't directly fix that, but it makes it easier to do and more likely to happen.)
