### PR TITLE
animate spinner while awaiting async operations in configure

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -23,6 +23,7 @@ var childProcess = require('child_process');
 var ghslug = promisify(require('github-slug'));
 var promptly = require('promisified-promptly');
 var readYaml = require('read-yaml');
+var cli = require('cli');
 var travisEncrypt = promisify(require('travis-encrypt'));
 var writeYaml = require('write-yaml');
 
@@ -160,12 +161,19 @@ module.exports = function() {
       if (error.message === 'Validation Failed' && error.errors[0].code === 'already_exists') {
         // XXX Should we prompt the user to confirm the deletion?
         // Perhaps they don't want to lose the existing token.
-        process.stdout.write(
-          'You already have the GitHub token "' + note + '".\n' +
-          'Deleting it…\n'
-        );
-        return getTokenId(note, noteUrl).then(deleteToken).then(function() {
+        var message =
+          'You already have the GitHub token "' + note + '".  Deleting it…';
+
+        cli.spinner(message);
+
+        return getTokenId(note, noteUrl)
+        .then(deleteToken)
+        .then(function() {
           return createToken(scopes, note, noteUrl);
+        })
+        .then(function(res) {
+          cli.spinner(message + ' done!', true);
+          return res;
         });
       }
       throw err;

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "templates/"
   ],
   "dependencies": {
+    "cli": "^0.11.1",
     "commander": "^2.8.1",
     "fs-extra": "^0.26.0",
     "gh-pages": "^0.5.0",


### PR DESCRIPTION
The _configure_ command engages in a variety of asynchronous operations as it initiates requests to the GitHub and Travis API endpoints and awaits their responses. While it's in a waiting state, it should use an animated spinner to indicate as much to the user, so it's more obvious that everything is well, and the user remains apprised of the state of the process.

This work-in-progress adds a spinner to a single async operation, the deletion of an existing GitHub token, as a proof-of-concept for this enhancement. Next I'll add them to all such operations.

(Here I'm also experimenting with using a _WIP_ label rather than a prefix on the issue title to indicate the work-in-progress status of this pull request. Feedback on that is also welcome!)
