### PR TITLE
Update glob version range

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "gitconfiglocal": "^1.0.0",
     "github": "^0.2.4",
     "github-slug": "^1.0.0",
-    "glob": ">=5.0.15 <=6.0.1",
+    "glob": "^5.0.15 || ^6.0.1",
     "gulp": "^3.9.0",
     "gulp-conflict": "^0.4.0",
     "gulp-connect": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "gitconfiglocal": "^1.0.0",
     "github": "^0.2.4",
     "github-slug": "^1.0.0",
-    "glob": "^5.0.15",
+    "glob": ">=5.0.15 <=6.0.1",
     "gulp": "^3.9.0",
     "gulp-conflict": "^0.4.0",
     "gulp-connect": "^2.2.0",


### PR DESCRIPTION
Instead of replacing `^5.0.15` by `^6.0.1`, I've used the range `^5.0.15 || ^6.0.1`.
This way an oghliner user forced to use 5.x for some reason could still install oghliner.

Is my understanding correct?
