### PR TITLE
rename project (fixes #23) — DON'T MERGE!

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-Oghliner is an experimental template and tool for deploying Offline Web Apps to GitHub Pages. As a template, Oghliner can be used to bootstrap an offline app that deploys to GitHub Pages. As a tool, Oghliner adds offlining and GitHub Pages deployment into your existing app.
+offline-github-pages is an experimental template and tool for deploying Offline Web Apps to GitHub Pages. As a template, offline-github-pages can be used to bootstrap an offline app that deploys to GitHub Pages. As a tool, offline-github-pages adds offlining and GitHub Pages deployment into your existing app.
 
 Offline Web Apps are web apps that work when your network doesn't. They use Service Workers to cache and serve your app's assets (HTML, JavaScript, CSS, images, etc.) on a user's machine, regardless of the status of its network connection. And they degrade gracefully, so the app works identically in browsers that don't support Service Workers when the machine is online.
 
-[![Build Status](https://travis-ci.org/mozilla/oghliner.svg?branch=master)](https://travis-ci.org/mozilla/oghliner)
-[![dependencies](https://david-dm.org/mozilla/oghliner.svg)](https://david-dm.org/mozilla/oghliner)
-[![devdependencies](https://david-dm.org/mozilla/oghliner/dev-status.svg)](https://david-dm.org/mozilla/oghliner#info=devDependencies)
+[![Build Status](https://travis-ci.org/mozilla/offline-github-pages.svg?branch=master)](https://travis-ci.org/mozilla/offline-github-pages)
+[![dependencies](https://david-dm.org/mozilla/offline-github-pages.svg)](https://david-dm.org/mozilla/offline-github-pages)
+[![devdependencies](https://david-dm.org/mozilla/offline-github-pages/dev-status.svg)](https://david-dm.org/mozilla/offline-github-pages#info=devDependencies)
 
 Using The Template
 ------------------
@@ -16,16 +16,16 @@ git clone git@github.com:mykmelez/test-app.git
 cd test-app
 ```
 
-If you haven't already, install gulp and oghliner.
+If you haven't already, install gulp and offline-github-pages.
 
 ```bash
-npm install -g gulp oghliner
+npm install -g gulp offline-github-pages
 ```
 
 Then bootstrap your app with the bootstrap command which puts assets in *app/* and includes a simple *gulpfile.js* that builds to *dist/*, but you can modify the build any way you like.
 
 ```bash
-oghliner bootstrap
+oghp bootstrap
 ```
 
 Invoke `gulp` to rebuild your app and regenerate the script that offlines it. Invoke `gulp deploy` to publish it to GitHub Pages.
@@ -34,7 +34,7 @@ Invoke `gulp` to rebuild your app and regenerate the script that offlines it. In
 gulp && gulp deploy
 ```
 
-At least one commit to the repository is required for successful deploy.  The following could be used to commit the changes by Oghliner to the repository:
+At least one commit to the repository is required for successful deploy.  The following could be used to commit the changes by offline-github-pages to the repository:
 
 ```bash
 git add . && git commit -m "Initial version of app"
@@ -43,20 +43,20 @@ git add . && git commit -m "Initial version of app"
 Using The Tool
 --------------
 
-To integrate offlining and deployment into your existing app, `npm install -g oghliner`, then run `oghliner offline [root-dir]` to offline your app (i.e. regenerate the offline-worker.js script) and `oghliner deploy [root-dir]` to deploy it.  Both commands take an optional *root-dir* argument that specifies the directory to offline/deploy. Its default value is the current directory (`./`).
+To integrate offlining and deployment into your existing app, `npm install -g offline-github-pages`, then run `oghp offline [root-dir]` to offline your app (i.e. regenerate the offline-worker.js script) and `oghp deploy [root-dir]` to deploy it.  Both commands take an optional *root-dir* argument that specifies the directory to offline/deploy. Its default value is the current directory (`./`).
 
 The *offline* command also allows you to specify these options:
 
 - *--file-globs*: a comma-separated list of file globs to offline (default: `**/*`). The files specified by *--file-globs* are matched inside *root-dir*.
 - *--import-scripts*: a comma-separated list of additional scripts to import into offline-worker.js. This is useful, for example, when you want to use the [Push API](https://developer.mozilla.org/en-US/docs/Web/API/Push_API).
 
-Alternately, you can `npm install --save oghliner` and then add tasks to your *gulpfile.js* which call *oghliner.offline* and *oghliner.deploy*, for example:
+Alternately, you can `npm install --save offline-github-pages` and then add tasks to your *gulpfile.js* which call *oghp.offline* and *oghp.deploy*, for example:
 
 ```js
-var oghliner = require('oghliner');
+var oghp = require('offline-github-pages');
 
 gulp.task('offline', function(callback) {
-  oghliner.offline({
+  oghp.offline({
     rootDir: 'dist/',
     fileGlobs: [
       '**/*.html',
@@ -66,37 +66,37 @@ gulp.task('offline', function(callback) {
 });
 
 gulp.task('deploy', function(callback) {
-  oghliner.deploy({
+  oghp.deploy({
     rootDir: 'dist/',
   }, callback);
 });
 ```
 
-The *oghliner.offline* task takes a *config* object and a *callback*. The properties of the *config* object are:
+The *oghp.offline* task takes a *config* object and a *callback*. The properties of the *config* object are:
 - *rootDir*: the directory to offline (default: `./`);
 - *fileGlobs*: an array of file globs to offline (default: `['**/*']`). The files specified by *fileGlobs* are matched inside *rootDir*.
 - *importScripts*: an array of additional scripts to import into offline-worker.js (default: `[]`). This is useful, for example, when you want to use the [Push API](https://developer.mozilla.org/en-US/docs/Web/API/Push_API).
 
-*oghliner.deploy* deploys your files to GitHub Pages. It takes a *config* object and a *callback*. The properties of the *config* object are:
+*oghp.deploy* deploys your files to GitHub Pages. It takes a *config* object and a *callback*. The properties of the *config* object are:
 
 - *rootDir*: the directory to deploy (default: `./`).
 
-Finally, in order for offline-worker.js to be evaluated, you need to load the offline manager script in your app by copying it to the location of your other scripts. To do this, use the *integrate* command (or *oghliner.integrate* function):
+Finally, in order for offline-worker.js to be evaluated, you need to load the offline manager script in your app by copying it to the location of your other scripts. To do this, use the *integrate* command (or *oghp.integrate* function):
 
 ```bash
-oghliner integrate path/to/your/scripts/
+oghp integrate path/to/your/scripts/
 ```
 
 Automatic Deployment Via Travis
 -------------------------------
 
-Oghliner can configure a repository to automatically deploy to GitHub Pages whenever you push to its *master* branch. Auto-deploy uses [Travis CI](https://travis-ci.org/), a continuous integration service. Oghliner takes care of most of the steps to configure your repository to auto-deploy via Travis.
+offline-github-pages can configure a repository to automatically deploy to GitHub Pages whenever you push to its *master* branch. Auto-deploy uses [Travis CI](https://travis-ci.org/), a continuous integration service. offline-github-pages takes care of most of the steps to configure your repository to auto-deploy via Travis.
 
 If you bootstrapped your app from the template, your repository already has a suitable Travis configuration file (.travis.yml) and a *configure* task in gulpfile.js. Just `gulp configure` to configure your repository.
 
-If you integrated the tool into an existing app, `npm install -g oghliner && oghliner configure` to configure your repository.
+If you integrated the tool into an existing app, `npm install -g offline-github-pages && oghp configure` to configure your repository.
 
-Oghliner will prompt you for your GitHub credentials in order to create a token that authorizes Travis to push changes to your repository. The token will give Travis limited access to your GitHub account. Specifically: it will have the *public_repo* [scope](https://developer.github.com/v3/oauth/#scopes), which gives it "read/write access to code, commit statuses, collaborators, and deployment statuses for public repositories and organizations."
+offline-github-pages will prompt you for your GitHub credentials in order to create a token that authorizes Travis to push changes to your repository. The token will give Travis limited access to your GitHub account. Specifically: it will have the *public_repo* [scope](https://developer.github.com/v3/oauth/#scopes), which gives it "read/write access to code, commit statuses, collaborators, and deployment statuses for public repositories and organizations."
 
 After configuring the repository, add and commit the changes to *.travis.yml* and push the *master* branch to the *origin* remote on GitHub to make Travis build and auto-deploy your app:
 

--- a/app/index.html
+++ b/app/index.html
@@ -3,8 +3,8 @@
 
   <head>
     <meta charset="utf-8">
-    <title>Oghliner</title>
-    <meta name="description" content="Oghliner : template and tool for deploying Offline Web Apps to GitHub Pages">
+    <title>offline-github-pages</title>
+    <meta name="description" content="offline-github-pages : template and tool for deploying Offline Web Apps to GitHub Pages">
 
     <link rel="shortcut icon" href="favicon.ico" type="image/x-icon"/>
     <link rel="apple-touch-icon-precomposed" sizes="57x57" href="images/apple-touch-icon-57x57.png" />
@@ -45,12 +45,12 @@
 
     <!-- MAIN CONTENT -->
     <main class="center">
-      <h1>Oghliner</h1>
+      <h1>offline-github-pages</h1>
       <h2 class="subtitle center-text">Deploy Offline Web Apps to GitHub Pages</h2>
 
       <section class="buttons">
-        <a href="https://github.com/mozilla/oghliner" class="button">Fork on GitHub</a>
-        <a href="https://www.npmjs.com/package/oghliner" class="button">Discover on npm</a>
+        <a href="https://github.com/mozilla/offline-github-pages" class="button">Fork on GitHub</a>
+        <a href="https://www.npmjs.com/package/offline-github-pages" class="button">Discover on npm</a>
       </section>
 
       <section>
@@ -92,9 +92,9 @@
     <!-- FOOTER  -->
     <footer class="inner">
       <p>
-        <span class="copyright">Oghliner is a <a href="https://github.com/mozilla">Mozilla</a> project.</span>
+        <span class="copyright">offline-github-pages is a <a href="https://github.com/mozilla">Mozilla</a> project.</span>
         &bull;
-        <a href="https://github.com/mozilla/oghliner">Oghliner on GitHub</a>
+        <a href="https://github.com/mozilla/offline-github-pages">offline-github-pages on GitHub</a>
       </p>
     </footer>
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -25,7 +25,7 @@ var template = require('gulp-template');
 var marked = require('marked');
 var argv = require('yargs').argv;
 
-var oghliner = require('./index.js');
+var oghp = require('./index.js');
 
 gulp.task('default', ['build', 'offline']);
 
@@ -47,16 +47,16 @@ gulp.task('build-tabzilla', ['copy-files'], function() {
   return gulp.src('node_modules/mozilla-tabzilla/**/*.{css,png}').pipe(gulp.dest('dist/styles/tabzilla'));
 });
 
-gulp.task('configure', oghliner.configure);
+gulp.task('configure', oghp.configure);
 
 gulp.task('deploy', function() {
-  return oghliner.deploy({
+  return oghp.deploy({
     rootDir: 'dist',
   });
 });
 
 gulp.task('offline', ['build'], function() {
-  return oghliner.offline({
+  return oghp.offline({
     rootDir: 'dist/',
     fileGlobs: [
       'images/**',

--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -92,9 +92,9 @@ function templateConfigToString(config) {
 
 function getDefaultTemplateConfig(dir) {
   var config = {
-    name: 'oghliner-template-app',
-    repository: 'https://oghliner-template-app.git',
-    description: 'A template app bootstrapped with oghliner.',
+    name: 'offline-github-pages-template-app',
+    repository: 'https://offline-github-pages-template-app.git',
+    description: 'A template app bootstrapped with offline-github-pages.',
     license: 'Apache-2.0',
   };
 
@@ -119,7 +119,7 @@ function sink() {
 module.exports = function(config) {
   config = config || {};
 
-  console.log('Bootstrapping current directory as Oghliner app…\n');
+  console.log('Bootstrapping current directory as offline-github-pages app…\n');
 
   var rootDir = config.rootDir ? config.rootDir : '.';
   return getDefaultTemplateConfig(rootDir)
@@ -167,11 +167,11 @@ module.exports = function(config) {
           console.log(
             'Your app has been bootstrapped! Just commit the changes and push the commit\n' +
             'to the origin/master branch:\n\n' +
-            chalk.bold('git add --all && git commit -m"initial version of Oghliner app"') + '\n' +
+            chalk.bold('git add --all && git commit -m"initial version of offline-github-pages app"') + '\n' +
             chalk.bold('git push origin master') + '\n\n' +
             'Then you can build, offline, and deploy the app using ' + chalk.bold.italic('gulp') + ' commands.\n\n' +
             chalk.bold.blue('ℹ For more information about building, offlining and deployment, see:\n' +
-            '    https://mozilla.github.io/oghliner/')
+            '    https://mozilla.github.io/offline-github-pages/')
           );
 
           resolve();

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -51,7 +51,7 @@ var github = new GitHub({
   // debug: true,
   protocol: 'https',
   headers: {
-    'user-agent': 'Oghliner',
+    'user-agent': 'offline-github-pages',
   },
 });
 
@@ -66,7 +66,7 @@ travis.users.sync.post = promisify(travis.users.sync.post);
 
 // The URL of this project, which we specify in the note_url field
 // when creating GitHub tokens.
-var noteUrl = 'https://github.com/mozilla/oghliner';
+var noteUrl = 'https://github.com/mozilla/offline-github-pages';
 
 // The active spinner message.  Used by interruptSpinner to replace
 // the active spinner message with an interrupted version of it.
@@ -325,7 +325,7 @@ module.exports = function() {
     startSpinner(message);
 
     return createToken(['read:org', 'user:email', 'repo_deployment', 'repo:status', 'write:repo_hook'],
-                       'temporary Oghliner token to get Travis token for ' + slug, noteUrl)
+                       'temporary offline-github-pages token to get Travis token for ' + slug, noteUrl)
     .then(function(res) {
       stopSpinner(message);
 
@@ -368,7 +368,7 @@ module.exports = function() {
     var message = 'Creating permanent GitHub token for Travis to push to the repository…';
     startSpinner(message);
 
-    return createToken(['public_repo'], 'Oghliner token for ' + slug, noteUrl)
+    return createToken(['public_repo'], 'offline-github-pages token for ' + slug, noteUrl)
     .then(function(res) {
       token = res.token;
       stopSpinner(message);

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -49,7 +49,7 @@ module.exports = function(config) {
     var cloneDir = config.cloneDir ? config.cloneDir : null;
 
     if (config.fileGlobs) {
-      var dir = temp.mkdirSync('oghliner');
+      var dir = temp.mkdirSync('offline-github-pages');
 
       config.fileGlobs.map(function(v) {
         return path.join(rootDir, v);
@@ -93,7 +93,7 @@ module.exports = function(config) {
 
         // We can't log on Travis because it would leak the GitHub token.
         // We can't use the gh-pages silent option because it makes error messages
-        // less informative (https://github.com/mozilla/oghliner/pull/58#issuecomment-147550610).
+        // less informative (https://github.com/mozilla/offline-github-pages/pull/58#issuecomment-147550610).
         ghPagesConfig.logger = ('GH_TOKEN' in process.env) ? function() {} : console.log;
 
         if ('GH_TOKEN' in process.env) {

--- a/lib/integrate.js
+++ b/lib/integrate.js
@@ -39,7 +39,7 @@ module.exports = function(config) {
   return new Promise(function(resolve, reject) {
     var dir = config.dir || './';
 
-    console.log('Integrating Oghliner into the app in the current directory…\n');
+    console.log('Integrating offline-github-pages into the app in the current directory…\n');
 
     startSpinner('Copying offline-manager.js to ' + dir + '…');
 
@@ -63,18 +63,18 @@ module.exports = function(config) {
           stopSpinner();
 
           console.log(
-            'Oghliner has been integrated into the app!\n\n' +
+            'offline-github-pages has been integrated into the app!\n\n' +
 
             'The app needs to load the script offline-manager.js in order to register\n' +
             'the service worker that offlines the app. To load the script, add this line\n' +
             'to the app\'s HTML page(s)/template(s):\n\n' +
             chalk.bold('<script src="' + dest + '"></script>') + '\n\n' +
             'And commit the changes and push the commit to the origin/master branch:\n\n' +
-            chalk.bold('git commit -m"integrate Oghliner" --all') + '\n' +
+            chalk.bold('git commit -m"integrate offline-github-pages" --all') + '\n' +
             chalk.bold('git push origin master') + '\n\n' +
             'Then you can offline and deploy the app using the ' + chalk.bold.italic('offline') + ' and ' + chalk.bold.italic('deploy') + ' commands.\n\n' +
             chalk.bold.blue('ℹ For more information about offlining and deployment, see:\n' +
-            '    https://mozilla.github.io/oghliner/')
+            '    https://mozilla.github.io/offline-github-pages/')
           );
 
           resolve();

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "oghliner",
+  "name": "offline-github-pages",
   "version": "0.10.1",
   "description": "template and tool for deploying Offline Web Apps to GitHub Pages",
   "main": "index.js",
@@ -8,10 +8,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/mozilla/oghliner/"
+    "url": "https://github.com/mozilla/offline-github-pages/"
   },
   "author": "Myk Melez <myk@mykzilla.org>",
-  "bin": "./cli.js",
+  "bin" : { "oghp" : "./cli.js" },
   "license": "Apache-2.0",
   "keywords": [
     "offline",

--- a/templates/app/index.html
+++ b/templates/app/index.html
@@ -56,7 +56,7 @@
     <!-- FOOTER  -->
     <div id="footer_wrap" class="outer">
       <footer class="inner">
-        <p class="copyright">Bootstrapped with <a href="https://github.com/mozilla/oghliner/">oghliner</a>.
+        <p class="copyright">Bootstrapped with <a href="https://github.com/mozilla/offline-github-pages/">offline-github-pages</a>.
       </footer>
     </div>
   </body>

--- a/templates/gulpfile.js
+++ b/templates/gulpfile.js
@@ -5,7 +5,7 @@
 
 var connect = require('gulp-connect');
 var gulp = require('gulp');
-var oghliner = require('oghliner');
+var oghp = require('offline-github-pages');
 
 gulp.task('default', ['build', 'offline']);
 
@@ -13,16 +13,16 @@ gulp.task('build', function(callback) {
   return gulp.src('app/**').pipe(gulp.dest('dist'));
 });
 
-gulp.task('configure', oghliner.configure);
+gulp.task('configure', oghp.configure);
 
 gulp.task('deploy', function() {
-  return oghliner.deploy({
+  return oghp.deploy({
     rootDir: 'dist',
   });
 });
 
 gulp.task('offline', ['build'], function() {
-  return oghliner.offline({
+  return oghp.offline({
     rootDir: 'dist/',
     fileGlobs: [
       'images/**',

--- a/templates/package.json
+++ b/templates/package.json
@@ -10,6 +10,6 @@
   "dependencies": {
     "gulp": "^3.9.0",
     "gulp-connect": "^2.2.0",
-    "oghliner": "^0.9.3"
+    "offline-github-pages": "^0.9.3"
   }
 }

--- a/test/liveUtils.js
+++ b/test/liveUtils.js
@@ -14,12 +14,12 @@ var github = new GitHub({
   version: '3.0.0',
   protocol: 'https',
   headers: {
-    'user-agent': 'Oghliner',
+    'user-agent': 'offline-github-pages',
   },
 });
 
 var liveUtils = {
-  repoName: 'test_oghliner_live_' + process.version + '_' + process.pid,
+  repoName: 'test_offline-github-pages_live_' + process.version + '_' + process.pid,
   githubNote: 'test' + process.version + '_' + process.pid,
   githubNoteURL: 'http://www.test.org/' + process.version + '_' + process.pid,
   githubToken: null,
@@ -215,7 +215,7 @@ function cleanup(username, password) {
       .catch(function() {
         // Ignore error if the authorization doesn't exist.
       }),
-      getTokenId(username, password, 'Oghliner token for ' + username + '/' + liveUtils.repoName, 'https://github.com/mozilla/oghliner')
+      getTokenId(username, password, 'offline-github-pages token for ' + username + '/' + liveUtils.repoName, 'https://github.com/mozilla/offline-github-pages')
       .then(deleteAuthorization)
       .catch(function() {
         // Ignore error if the authorization doesn't exist.

--- a/test/testBootstrap.js
+++ b/test/testBootstrap.js
@@ -13,11 +13,11 @@ describe('Bootstrap', function() {
   var oldWd;
   before(function() {
     temp.track();
-    return temp.mkdir('oghliner').then(function(dirPath) {
+    return temp.mkdir('offline-github-pages').then(function(dirPath) {
       oldWd = process.cwd();
       process.chdir(dirPath);
       childProcess.execSync('git init');
-      childProcess.execSync('git remote add upstream https://github.com/mozilla/oghliner.git');
+      childProcess.execSync('git remote add upstream https://github.com/mozilla/offline-github-pages.git');
       return bootstrap({
         template: {
           name: appName

--- a/test/testConfigure.js
+++ b/test/testConfigure.js
@@ -14,7 +14,7 @@ var temp = promisify(require('temp').track());
 var configure = require('../lib/configure');
 
 describe('Configure', function() {
-  var slug = 'mozilla/oghliner', user = 'mozilla', repo = 'oghliner';
+  var slug = 'mozilla/offline-github-pages', user = 'mozilla', repo = 'offline-github-pages';
 
   var write = process.stdout.write;
   var output;
@@ -99,11 +99,11 @@ describe('Configure', function() {
 
   var oldWd;
   beforeEach(function() {
-    return temp.mkdir('oghliner').then(function(dirPath) {
+    return temp.mkdir('offline-github-pages').then(function(dirPath) {
       oldWd = process.cwd();
       process.chdir(dirPath);
       childProcess.execSync('git init');
-      childProcess.execSync('git remote add origin https://github.com/mozilla/oghliner.git');
+      childProcess.execSync('git remote add origin https://github.com/mozilla/offline-github-pages.git');
       output = '';
       waitingArr = [];
     });
@@ -161,8 +161,8 @@ describe('Configure', function() {
     return nock('https://api.github.com:443')
     .post('/authorizations', {
       "scopes":["public_repo"],
-      "note":"Oghliner token for " + slug,
-      "note_url":"https://github.com/mozilla/oghliner"
+      "note":"offline-github-pages token for " + slug,
+      "note_url":"https://github.com/mozilla/offline-github-pages"
     })
     .reply(422, {
       "message":"Validation Failed",
@@ -175,22 +175,22 @@ describe('Configure', function() {
     return nock('https://api.github.com:443')
     .post('/authorizations', {
       "scopes":["public_repo"],
-      "note":"Oghliner token for " + slug,
-      "note_url":"https://github.com/mozilla/oghliner"
+      "note":"offline-github-pages token for " + slug,
+      "note_url":"https://github.com/mozilla/offline-github-pages"
     })
     .reply(201, {
       "id":23157724,
       "url":"https://api.github.com/authorizations/23157724",
       "app":{
-        "name":"Oghliner token for " + slug,
-        "url":"https://github.com/mozilla/oghliner",
+        "name":"offline-github-pages token for " + slug,
+        "url":"https://github.com/mozilla/offline-github-pages",
         "client_id":"00000000000000000000"
       },
       "token":"0000000000000000000000000000000000000000", // removed
       "hashed_token":"0000000000000000000000000000000000000000000000000000000000000000", // removed
       "token_last_eight":"00000000", // removed
-      "note":"Oghliner token for mykmelez/oghliner",
-      "note_url":"https://github.com/mozilla/oghliner",
+      "note":"offline-github-pages token for mykmelez/offline-github-pages",
+      "note_url":"https://github.com/mozilla/offline-github-pages",
       "created_at":"2015-10-12T21:42:59Z",
       "updated_at":"2015-10-12T21:42:59Z",
       "scopes":["public_repo"],
@@ -202,8 +202,8 @@ describe('Configure', function() {
     return nock('https://api.github.com:443')
     .post('/authorizations', {
       "scopes":["public_repo"],
-      "note":"Oghliner token for " + slug,
-      "note_url":"https://github.com/mozilla/oghliner"
+      "note":"offline-github-pages token for " + slug,
+      "note_url":"https://github.com/mozilla/offline-github-pages"
     })
     .reply(401, {
       "message":"Must specify two-factor authentication OTP code.",
@@ -215,20 +215,20 @@ describe('Configure', function() {
     return nock('https://api.github.com:443')
     .post('/authorizations', {
       "scopes":["read:org","user:email","repo_deployment","repo:status","write:repo_hook"],
-      "note":"temporary Oghliner token to get Travis token for " + slug,
-      "note_url":"https://github.com/mozilla/oghliner"
+      "note":"temporary offline-github-pages token to get Travis token for " + slug,
+      "note_url":"https://github.com/mozilla/offline-github-pages"
     })
     .reply(201, {
       "id":23157726,
       "url":"https://api.github.com/authorizations/23157726",
-      "app":{"name":"temporary Oghliner token to get Travis token for " + slug,
-      "url":"https://github.com/mozilla/oghliner",
+      "app":{"name":"temporary offline-github-pages token to get Travis token for " + slug,
+      "url":"https://github.com/mozilla/offline-github-pages",
       "client_id":"00000000000000000000"},
       "token":"1111111111111111111111111111111111111111",
       "hashed_token":"1111111111111111111111111111111111111111111111111111111111111111",
       "token_last_eight":"11111111",
-      "note":"temporary Oghliner token to get Travis token for " + slug,
-      "note_url":"https://github.com/mozilla/oghliner",
+      "note":"temporary offline-github-pages token to get Travis token for " + slug,
+      "note_url":"https://github.com/mozilla/offline-github-pages",
       "created_at":"2015-10-12T21:43:00Z",
       "updated_at":"2015-10-12T21:43:00Z",
       "scopes":["read:org","user:email","repo_deployment","repo:status","write:repo_hook"],
@@ -485,14 +485,14 @@ describe('Configure', function() {
     .reply(200, [{
       "id":22200031,
       "url":"https://api.github.com/authorizations/22200031",
-      "app":{"name":"Oghliner token for " + slug,
-      "url":"https://github.com/mozilla/oghliner",
+      "app":{"name":"offline-github-pages token for " + slug,
+      "url":"https://github.com/mozilla/offline-github-pages",
       "client_id":"00000000000000000000"},
       "token":"",
       "hashed_token":"0000000000000000000000000000000000000000000000000000000000000000", // removed
       "token_last_eight":"00000000", // removed
-      "note":"Oghliner token for " + slug,
-      "note_url":"https://github.com/mozilla/oghliner",
+      "note":"offline-github-pages token for " + slug,
+      "note_url":"https://github.com/mozilla/offline-github-pages",
       "created_at":"2015-09-16T20:08:41Z",
       "updated_at":"2015-09-16T20:08:41Z",
       "scopes":["public_repo"],

--- a/test/testDeploy.js
+++ b/test/testDeploy.js
@@ -17,7 +17,7 @@ describe('Deploy', function() {
   });
 
   it('should create a gh-pages branch in the origin repo and publish files to it', function(done) {
-    var dir = temp.mkdirSync('oghliner');
+    var dir = temp.mkdirSync('offline-github-pages');
 
     var simpleGit = require('simple-git')(dir);
 
@@ -51,7 +51,7 @@ describe('Deploy', function() {
   });
 
   it('should create a gh-pages branch in the origin repo and publish only the specified files to it', function(done) {
-    var dir = temp.mkdirSync('oghliner');
+    var dir = temp.mkdirSync('offline-github-pages');
 
     var simpleGit = require('simple-git')(dir);
 
@@ -90,7 +90,7 @@ describe('Deploy', function() {
   });
 
   it('should update the gh-pages branch in the origin repo and publish files to it', function(done) {
-    var dir = temp.mkdirSync('oghliner');
+    var dir = temp.mkdirSync('offline-github-pages');
 
     var simpleGit = require('simple-git')(dir);
 
@@ -131,12 +131,12 @@ describe('Deploy', function() {
 
   function deployDifferentRepoURL(done, repoURL) {
     ghPages.publish = function(dir, config, callback) {
-      assert.equal(config.repo, 'https://oghliner@github.com/mozilla/oghliner.git');
+      assert.equal(config.repo, 'https://offline-github-pages@github.com/mozilla/offline-github-pages.git');
       callback();
     };
-    process.env.GH_TOKEN = 'oghliner';
+    process.env.GH_TOKEN = 'offline-github-pages';
 
-    var dir = temp.mkdirSync('oghliner');
+    var dir = temp.mkdirSync('offline-github-pages');
 
     var simpleGit = require('simple-git')(dir);
 
@@ -161,15 +161,15 @@ describe('Deploy', function() {
   }
 
   it('should try to publish with a different repo URL (HTTPS)', function(done) {
-    deployDifferentRepoURL(done, 'https://github.com/mozilla/oghliner.git');
+    deployDifferentRepoURL(done, 'https://github.com/mozilla/offline-github-pages.git');
   });
 
   it('should try to publish with a different repo URL (SSH)', function(done) {
-    deployDifferentRepoURL(done, 'git@github.com:mozilla/oghliner.git');
+    deployDifferentRepoURL(done, 'git@github.com:mozilla/offline-github-pages.git');
   });
 
   function deployNoOriginRemote(done) {
-    var dir = temp.mkdirSync('oghliner');
+    var dir = temp.mkdirSync('offline-github-pages');
 
     var simpleGit = require('simple-git')(dir);
 
@@ -194,12 +194,12 @@ describe('Deploy', function() {
   it('should fail if there is no origin remote', deployNoOriginRemote);
 
   it('should fail if there is no origin remote', function(done) {
-    process.env.GH_TOKEN = 'oghliner';
+    process.env.GH_TOKEN = 'offline-github-pages';
     deployNoOriginRemote(done);
   });
 
   function deployOutsideRepo(message) {
-    var dir = temp.mkdirSync('oghliner');
+    var dir = temp.mkdirSync('offline-github-pages');
 
     process.chdir(dir);
 
@@ -221,16 +221,16 @@ describe('Deploy', function() {
   });
 
   it('should fail if called outside of a git repository (on Travis) with no commit message', function() {
-    process.env.GH_TOKEN = 'oghliner';
+    process.env.GH_TOKEN = 'offline-github-pages';
     return deployOutsideRepo();
   });
   it('should fail if called outside of a git repository (on Travis) with commit message', function() {
-    process.env.GH_TOKEN = 'oghliner';
+    process.env.GH_TOKEN = 'offline-github-pages';
     return deployOutsideRepo('message');
   });
 
   it('should succeed if there\'s a node_modules directory in the rootDir', function(done) {
-    var dir = temp.mkdirSync('oghliner');
+    var dir = temp.mkdirSync('offline-github-pages');
 
     var simpleGit = require('simple-git')(dir);
 

--- a/test/testLiveAsTemplate.js
+++ b/test/testLiveAsTemplate.js
@@ -14,7 +14,7 @@ if (!username || !password) {
   return;
 }
 
-describe('CLI interface, oghliner as a template', function() {
+describe('CLI interface, offline-github-pages as a template', function() {
   this.timeout(0);
 
   var oldWD = process.cwd();
@@ -28,7 +28,7 @@ describe('CLI interface, oghliner as a template', function() {
   });
 
   beforeEach(function() {
-    process.chdir(temp.mkdirSync('oghliner'));
+    process.chdir(temp.mkdirSync('offline-github-pages'));
 
     process.env.GH_TOKEN = username + ':' + liveUtils.githubToken;
 
@@ -49,19 +49,19 @@ describe('CLI interface, oghliner as a template', function() {
     .then(liveUtils.spawn.bind(null, 'git', ['clone', 'https://' + username + ':' + liveUtils.githubToken + '@github.com/' + username + '/' + liveUtils.repoName]))
     .then(process.chdir.bind(null, liveUtils.repoName))
     .then(liveUtils.spawn.bind(null, 'npm', ['install', path.dirname(__dirname)]))
-    .then(liveUtils.spawn.bind(null, path.join('node_modules', '.bin', 'oghliner'), ['bootstrap', '.'], [
+    .then(liveUtils.spawn.bind(null, path.join('node_modules', '.bin', 'offline-github-pages'), ['bootstrap', '.'], [
       {
         q: 'Would you like to change its configuration (y/N)?',
         r: 'n',
       }
     ]))
-    // Overwrite the oghliner version installed by bootstrap with the development one from the top directory.
+    // Overwrite the offline-github-pages version installed by bootstrap with the development one from the top directory.
     .then(liveUtils.spawn.bind(null, 'npm', ['install', path.dirname(__dirname)]))
     .then(function() {
       assert.doesNotThrow(fse.statSync.bind(fse, 'README.md'));
       assert.doesNotThrow(fse.statSync.bind(fse, 'app'));
       var packageJson = JSON.parse(fse.readFileSync('package.json', 'utf8'));
-      expect(packageJson.name).to.equal('oghliner-template-app');
+      expect(packageJson.name).to.equal('offline-github-pages-template-app');
       expect(packageJson.license).to.equal('Apache-2.0');
       expect(packageJson).to.include.keys('version');
       expect(packageJson).to.include.keys('description');
@@ -80,7 +80,7 @@ describe('CLI interface, oghliner as a template', function() {
       .catch(liveUtils.getBranch.bind(null, username))
       .catch(liveUtils.getBranch.bind(null, username))
     })
-    .then(liveUtils.spawn.bind(null, path.join('node_modules', '.bin', 'oghliner'), ['configure'], [
+    .then(liveUtils.spawn.bind(null, path.join('node_modules', '.bin', 'offline-github-pages'), ['configure'], [
       {
         q: 'Username: ',
         r: username,

--- a/test/testLiveAsTool.js
+++ b/test/testLiveAsTool.js
@@ -14,7 +14,7 @@ if (!username || !password) {
   return;
 }
 
-describe('CLI interface, oghliner as a tool', function() {
+describe('CLI interface, offline-github-pages as a tool', function() {
   this.timeout(0);
 
   var oldWD = process.cwd();
@@ -28,7 +28,7 @@ describe('CLI interface, oghliner as a tool', function() {
   });
 
   beforeEach(function() {
-    process.chdir(temp.mkdirSync('oghliner'));
+    process.chdir(temp.mkdirSync('offline-github-pages'));
 
     process.env.GH_TOKEN = username + ':' + liveUtils.githubToken;
 
@@ -53,15 +53,15 @@ describe('CLI interface, oghliner as a tool', function() {
       fse.mkdirSync('dist');
     })
     .then(fse.writeFileSync.bind(fse, 'dist/index.html', '<html></html>'))
-    .then(liveUtils.spawn.bind(null, path.join('node_modules', '.bin', 'oghliner'), ['offline', 'dist']))
-    .then(liveUtils.spawn.bind(null, path.join('node_modules', '.bin', 'oghliner'), ['integrate', 'dist']))
-    .then(liveUtils.spawn.bind(null, path.join('node_modules', '.bin', 'oghliner'), ['deploy', 'dist']))
+    .then(liveUtils.spawn.bind(null, path.join('node_modules', '.bin', 'offline-github-pages'), ['offline', 'dist']))
+    .then(liveUtils.spawn.bind(null, path.join('node_modules', '.bin', 'offline-github-pages'), ['integrate', 'dist']))
+    .then(liveUtils.spawn.bind(null, path.join('node_modules', '.bin', 'offline-github-pages'), ['deploy', 'dist']))
     .then(function() {
       return liveUtils.getBranch(username)
       .catch(liveUtils.getBranch.bind(null, username))
       .catch(liveUtils.getBranch.bind(null, username))
     })
-    .then(liveUtils.spawn.bind(null, path.join('node_modules', '.bin', 'oghliner'), ['configure'], [
+    .then(liveUtils.spawn.bind(null, path.join('node_modules', '.bin', 'offline-github-pages'), ['configure'], [
       {
         q: 'Username: ',
         r: username,
@@ -110,7 +110,7 @@ describe('CLI interface, oghliner as a tool', function() {
 
   it('the CLI program should have an exit code != 0 if deploy fails', function() {
     return liveUtils.spawn('npm', ['install', path.dirname(__dirname)])
-    .then(liveUtils.spawn.bind(null, path.join('node_modules', '.bin', 'oghliner'), ['deploy']))
+    .then(liveUtils.spawn.bind(null, path.join('node_modules', '.bin', 'offline-github-pages'), ['deploy']))
     .then(function() {
       assert(false);
     }, function(err) {

--- a/test/testOffline.js
+++ b/test/testOffline.js
@@ -49,7 +49,7 @@ describe('Offline', function() {
   });
 
   it('should create offline-worker.js in the destination directory', function() {
-    var dir = temp.mkdirSync('oghliner');
+    var dir = temp.mkdirSync('offline-github-pages');
 
     return offline({
       rootDir: dir,
@@ -59,7 +59,7 @@ describe('Offline', function() {
   });
 
   it('should not fail if the destination directory already contains a offline-worker.js file', function() {
-    var dir = temp.mkdirSync('oghliner');
+    var dir = temp.mkdirSync('offline-github-pages');
 
     fs.writeFileSync(path.join(dir, 'offline-worker.js'), 'something');
 
@@ -72,7 +72,7 @@ describe('Offline', function() {
   });
 
   it('should use importScript in the service worker if the importScripts option is defined', function() {
-    var dir = temp.mkdirSync('oghliner');
+    var dir = temp.mkdirSync('offline-github-pages');
     fs.writeFileSync(path.join(dir, 'a-script.js'), 'data');
 
     return offline({
@@ -85,7 +85,7 @@ describe('Offline', function() {
   });
 
   it('should fail if an entry in importScript is a directory', function() {
-    var dir = temp.mkdirSync('oghliner');
+    var dir = temp.mkdirSync('offline-github-pages');
     fs.mkdirSync(path.join(dir, 'subDir'));
 
     return offline({
@@ -99,7 +99,7 @@ describe('Offline', function() {
   });
 
   it('should fail if a file in importScript doesn\'t exist', function() {
-    var dir = temp.mkdirSync('oghliner');
+    var dir = temp.mkdirSync('offline-github-pages');
 
     return offline({
       rootDir: dir,
@@ -112,13 +112,13 @@ describe('Offline', function() {
   });
 
   it('should use the GitHub slug as the cache ID if it is available', function() {
-    var rootDir = temp.mkdirSync('oghliner');
+    var rootDir = temp.mkdirSync('offline-github-pages');
     var dir = path.join(rootDir, 'dist');
     fs.mkdirSync(dir);
 
     offline.__set__('ghslug', function(path) {
       return new Promise(function(resolve, reject) {
-        resolve('mozilla/oghliner');
+        resolve('mozilla/offline-github-pages');
       });
     });
 
@@ -128,12 +128,12 @@ describe('Offline', function() {
       rootDir: dir,
     }).then(function() {
       var content = fs.readFileSync(path.join(dir, 'offline-worker.js'), 'utf8');
-      assert.notEqual(content.indexOf('mozilla/oghliner'), -1);
+      assert.notEqual(content.indexOf('mozilla/offline-github-pages'), -1);
     });
   });
 
   it('should use the app name from package.json as the cache ID if the GitHub slug is not available', function() {
-    var rootDir = temp.mkdirSync('oghliner');
+    var rootDir = temp.mkdirSync('offline-github-pages');
     var dir = path.join(rootDir, 'dist');
     fs.mkdirSync(dir);
 
@@ -152,7 +152,7 @@ describe('Offline', function() {
   });
 
   it('should not fail if both the GitHub slug and package.json are not available', function() {
-    var rootDir = temp.mkdirSync('oghliner');
+    var rootDir = temp.mkdirSync('offline-github-pages');
     var dir = path.join(rootDir, 'dist');
     fs.mkdirSync(dir);
 
@@ -166,7 +166,7 @@ describe('Offline', function() {
   });
 
   it('should cache files in rootDir', function() {
-    var rootDir = temp.mkdirSync('oghliner');
+    var rootDir = temp.mkdirSync('offline-github-pages');
     var dir = path.join(rootDir, 'dist');
     fs.mkdirSync(dir);
 
@@ -187,7 +187,7 @@ describe('Offline', function() {
   });
 
   it('should not cache files in rootDir that do not match fileGlobs', function() {
-    var rootDir = temp.mkdirSync('oghliner');
+    var rootDir = temp.mkdirSync('offline-github-pages');
     var dir = path.join(rootDir, 'dist');
     fs.mkdirSync(dir);
 
@@ -212,7 +212,7 @@ describe('Offline', function() {
   });
 
   it('should cache files in a subdirectory of rootDir', function() {
-    var rootDir = temp.mkdirSync('oghliner');
+    var rootDir = temp.mkdirSync('offline-github-pages');
     var dir = path.join(rootDir, 'dist');
     fs.mkdirSync(dir);
     var subDir = path.join(dir, 'subdir');
@@ -235,7 +235,7 @@ describe('Offline', function() {
   });
 
   it('should cache large files', function() {
-    var rootDir = temp.mkdirSync('oghliner');
+    var rootDir = temp.mkdirSync('offline-github-pages');
     var dir = path.join(rootDir, 'dist');
     fs.mkdirSync(dir);
 
@@ -266,7 +266,7 @@ describe('Offline', function() {
   });
 
   it('should not cache excluded files', function() {
-    var rootDir = temp.mkdirSync('oghliner');
+    var rootDir = temp.mkdirSync('offline-github-pages');
     var dir = path.join(rootDir, 'dist');
     fs.mkdirSync(dir);
 
@@ -301,7 +301,7 @@ describe('Offline', function() {
   });
 
   it('should not warn about explicitly included files', function() {
-    var rootDir = temp.mkdirSync('oghliner');
+    var rootDir = temp.mkdirSync('offline-github-pages');
     var dir = path.join(rootDir, 'dist');
     fs.mkdirSync(dir);
 


### PR DESCRIPTION
This is what it'd look like to rename the project to _offline-github-pages_ while calling the command-line tool _oghp_. This is a complete fix for #23 (the only test failure is due to _offline-github-pages_ not yet existing in npm), but I've labeled it WIP (and marked it `DON'T MERGE!`) because I'm still not sure that we should do it.

I'll decide by tomorrow, but at the moment, after looking at this, I'm leaning against changing the name, since it's easier to remember the name of the command-line tool if it's the same name as the package (and project), and offline-github-pages is long and cumbersome as a name for a command-line tool.
