### PR TITLE
fix configure auth check when 2FA code needed

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -153,7 +153,9 @@ module.exports = function() {
   function checkCredentials() {
     var message = 'Checking credentials…';
     startSpinner(message);
-    return github.authorization.getAll({})
+    return github.authorization.getAll({
+      headers: otpCode ? { 'X-GitHub-OTP': otpCode } : {},
+    })
     .then(function() {
       stopSpinner(message);
     })


### PR DESCRIPTION
One of the last changes on the configure clarification branch broke authentication via auth code because it didn't pass the auth code when checking credentials, which now happens repeatedly until the credentials are correct. Here's the fix.
