### PR TITLE
sync template's Oghliner dependency w/current version of Oghliner

### DIFF
--- a/templates/package.json
+++ b/templates/package.json
@@ -10,6 +10,6 @@
   "dependencies": {
     "gulp": "^3.9.0",
     "gulp-connect": "^2.2.0",
-    "oghliner": "^0.9.3"
+    "oghliner": "^0.11.0"
   }
 }


### PR DESCRIPTION
We should keep these in sync.
