### PR TITLE
make 'gulp build' and 'gulp offline' explicit build steps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_script:
   - 'git config --global user.name "Travis-CI"'
   - 'git config --global user.email "myk@mykzilla.org"'
 script:
-  - gulp
+  - gulp build && gulp offline
   - gulp test
 after_success:
   - 'echo "travis_fold:end:after_success" && [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ "${TRAVIS_BRANCH}" = "master" ] && [ "${TRAVIS_NODE_VERSION}" = "0.12" ] && echo "Deploying…" && gulp deploy'

--- a/README.md
+++ b/README.md
@@ -1,56 +1,316 @@
-Oghliner is an experimental template and tool for deploying Offline Web Apps to GitHub Pages. As a template, Oghliner can be used to bootstrap an offline app that deploys to GitHub Pages. As a tool, Oghliner adds offlining and GitHub Pages deployment into your existing app.
-
-Offline Web Apps are web apps that work when your network doesn't. They use Service Workers to cache and serve your app's assets (HTML, JavaScript, CSS, images, etc.) on a user's machine, regardless of the status of its network connection. And they degrade gracefully, so the app works identically in browsers that don't support Service Workers when the machine is online.
-
 [![Build Status](https://travis-ci.org/mozilla/oghliner.svg?branch=master)](https://travis-ci.org/mozilla/oghliner)
 [![dependencies](https://david-dm.org/mozilla/oghliner.svg)](https://david-dm.org/mozilla/oghliner)
 [![devdependencies](https://david-dm.org/mozilla/oghliner/dev-status.svg)](https://david-dm.org/mozilla/oghliner#info=devDependencies)
 
-Using The Template
-------------------
+# Oghliner
 
-To bootstrap an offline web app, create a repository on GitHub and then clone to your local machine.
+Oghliner is a Node tool to deploy Offline Web Apps to GitHub Pages.
 
-```bash
-git clone git@github.com:mykmelez/test-app.git
-cd test-app
+Offline Web Apps are web apps that cache their files (HTML, JavaScript, CSS, images, etc.) on the client, so they work even when your network doesn't. [GitHub Pages](https://pages.github.com/) is a simple host for static files.
+
+Oghliner offlines an app by generating a [Service Worker](https://github.com/slightlyoff/ServiceWorker/blob/master/explainer.md) for it. It deploys the app by committing it to the *gh-pages* branch of the repository being deployed.
+
+Oghliner includes commands for bootstrapping an app from scratch or integrating its functionality into your existing app. It can also configure [Travis CI](https://travis-ci.org) to automatically deploy your app when you merge changes to its master branch.
+
+Oghliner has both command-line and module interfaces and provides five commands: *bootstrap*, *integrate*, *offline*, *deploy*, and *configure*. All commands are available via both interfaces, but the CLI is more appropriate for the *bootstrap*, *integrate*, and *configure* commands, which you'll invoke at most once per app; while the module is more appropriate for the *offline* and *deploy* commands, which you'll call each time you change your app and rebuild it.
+
+## Getting Started
+
+To use the CLI, install Oghliner globally:
+
+```
+npm install --global oghliner
 ```
 
-If you haven't already, install gulp and oghliner.
+To use the module, install Oghliner locally and save it to your *dependencies*:
 
-```bash
-npm install -g gulp oghliner
+```
+npm install --save oghliner
 ```
 
-Then bootstrap your app with the bootstrap command which puts assets in *app/* and includes a simple *gulpfile.js* that builds to *dist/*, but you can modify the build any way you like.
+Then *require* it in your script(s):
 
-```bash
+```js
+var oghliner = require('oghliner');
+```
+
+## Bootstrap
+
+The *bootstrap* command creates an initial set of directories and files for a new app. To use it, first [create a repository on GitHub](https://github.com/new) and clone it to your local machine:
+
+```
+git clone git@github.com:mykmelez/offline-app.git
+```
+
+Then change to its working directory and invoke `oghliner bootstrap`:
+
+```
+cd offline-app/
 oghliner bootstrap
 ```
 
-Invoke `gulp` to rebuild your app and regenerate the script that offlines it. Invoke `gulp deploy` to publish it to GitHub Pages.
+Oghliner will bootstrap your app by copying files from its app template to the current directory:
 
-```bash
-gulp && gulp deploy
+```
+Bootstrapping current directory as Oghliner app…
+
+Your app's configuration is:
+
+Name: offline-app
+Repository: git@github.com:mykmelez/offline-app.git
+Description: A template app bootstrapped with oghliner.
+License: Apache-2.0
+
+Would you like to change its configuration (y/N)? n
+
+Creating files…
+✓ Creating README.md
+✓ Creating app
+✓ Creating .gitignore
+✓ Creating gulpfile.js
+✓ Creating package.json
+✓ Creating app/favicon.ico
+✓ Creating app/fonts
+✓ Creating app/images
+✓ Creating app/index.html
+✓ Creating app/robots.txt
+✓ Creating app/scripts
+✓ Creating app/styles
+✓ Creating app/images/apple-touch-icon-114x114.png
+✓ Creating app/images/apple-touch-icon-120x120.png
+✓ Creating app/images/apple-touch-icon-144x144.png
+✓ Creating app/images/apple-touch-icon-152x152.png
+✓ Creating app/images/apple-touch-icon-57x57.png
+✓ Creating app/images/apple-touch-icon-60x60.png
+✓ Creating app/images/apple-touch-icon-72x72.png
+✓ Creating app/images/apple-touch-icon-76x76.png
+✓ Creating app/images/favicon-128x128.png
+✓ Creating app/images/favicon-16x16.png
+✓ Creating app/images/favicon-196x196.png
+✓ Creating app/images/favicon-32x32.png
+✓ Creating app/images/favicon-96x96.png
+✓ Creating app/images/mstile-144x144.png
+✓ Creating app/images/mstile-150x150.png
+✓ Creating app/images/mstile-310x150.png
+✓ Creating app/images/mstile-310x310.png
+✓ Creating app/images/mstile-70x70.png
+✓ Creating app/scripts/main.js
+✓ Creating app/scripts/offline-manager.js
+✓ Creating app/styles/stylesheet.css
+
+✓ Creating files… done!
+✓ Installing npm dependencies… done!
+
+Your app has been bootstrapped! Just commit the changes and push the commit
+to the origin/master branch:
+
+git add --all && git commit -m"initial version of Oghliner app"
+git push origin master
+
+Then you can build, offline, and deploy the app using gulp commands.
+
+ℹ For more information about building, offlining and deployment, see:
+    https://mozilla.github.io/oghliner/
 ```
 
-At least one commit to the repository is required for successful deploy.  The following could be used to commit the changes by Oghliner to the repository:
+Then just commit the changes and push the commit to the origin/master branch:
 
-```bash
-git add . && git commit -m "Initial version of app"
+```
+git add --all && git commit -m"initial version of Oghliner app"
+git push origin master
 ```
 
-Using The Tool
---------------
+Note: To bootstrap an app into a different directory than the current one, specify its path when invoking *bootstrap*:
 
-To integrate offlining and deployment into your existing app, `npm install -g oghliner`, then run `oghliner offline [root-dir]` to offline your app (i.e. regenerate the offline-worker.js script) and `oghliner deploy [root-dir]` to deploy it.  Both commands take an optional *root-dir* argument that specifies the directory to offline/deploy. Its default value is the current directory (`./`).
+```
+oghliner bootstrap path/to/another/clone/
+```
 
-The *offline* command also allows you to specify these options:
+## Integrate
 
-- *--file-globs*: a comma-separated list of file globs to offline (default: `**/*`). The files specified by *--file-globs* are matched inside *root-dir*.
-- *--import-scripts*: a comma-separated list of additional scripts to import into offline-worker.js. This is useful, for example, when you want to use the [Push API](https://developer.mozilla.org/en-US/docs/Web/API/Push_API).
+The *integrate* command adds Oghliner functionality into an existing app. To use it, invoke `oghliner integrate`, passing it the path to the directory containing your app's scripts:
 
-Alternately, you can `npm install --save oghliner` and then add tasks to your *gulpfile.js* which call *oghliner.offline* and *oghliner.deploy*, for example:
+```
+oghliner integrate app/scripts/
+```
+
+Oghliner will copy the *offline-manager.js* script to that directory:
+
+```
+Integrating Oghliner into the app in the current directory…
+
+✓ Copying offline-manager.js to app/scripts/… done!
+
+Oghliner has been integrated into the app!
+
+The app needs to load the script offline-manager.js in order to register
+the service worker that offlines the app. To load the script, add this line
+to the app's HTML page(s)/template(s):
+
+<script src="app/scripts/offline-manager.js"></script>
+
+And commit the changes and push the commit to the origin/master branch:
+
+git commit -m"integrate Oghliner" --all
+git push origin master
+
+Then you can offline and deploy the app using the offline and deploy commands.
+
+ℹ For more information about offlining and deployment, see:
+    https://mozilla.github.io/oghliner/
+```
+
+Then add a &lt;script> tag referencing that script to your app's HTML page(s)/template(s). Oghliner will suggest one, but it doesn't necessarily know your app's directory structure, so make sure it contains the correct path to the file!
+
+## Offline
+
+The *offline* command generates a service worker that caches your app's files on the client.
+
+To use it via the command line, invoke `oghliner offline`, passing it a *rootDir* argument specifying the directory containing the files to offline:
+
+```
+oghliner offline dist/
+```
+
+To use it via the module, call `oghliner.offline`, passing it an *options* object with a *rootDir* property specifying the directory containing the files to offline:
+
+```js
+oghliner.offline({
+  rootDir: 'dist/',
+});
+```
+
+If left unspecified, the default value of *rootDir* is `./`, i.e. the current directory.
+
+Note: *rootDir* should be the *target* directory containing the output of your build process, not the *source* directory containing the original files. For example, if your source files are in *app/*, and your build process outputs into *dist/*, then you should specify the *dist/* directory.
+
+### Options
+
+The *offline* command takes the following options:
+
+- `--file-globs glob,…` or `fileGlobs: ['glob', …]` - a comma-separated list of globs identifying the files to offline (default: `**/*`). The globs are matched inside *rootDir*.
+- `--import-scripts script,…` or `importScripts: ['script', …]` - a comma-separated list of additional scripts to evaluate in the service worker (no default value). This is useful, for example, when you want to use the [Push API](https://developer.mozilla.org/en-US/docs/Web/API/Push_API).
+
+## Deploy
+
+The *deploy* command deploys your app to GitHub Pages by committing its files to the *gh-pages* branch of the repository and pushing the commit to GitHub.
+
+To use it via the command line, invoke `oghliner deploy`, passing it a *rootDir* argument specifying the directory containing the files to deploy:
+
+```
+oghliner deploy dist/
+```
+
+To use it via the module, call `oghliner.deploy`, passing it an *options* object with a *rootDir* property specifying the directory containing the files to deploy:
+
+```js
+oghliner.deploy({
+  rootDir: 'dist/',
+});
+```
+
+If left unspecified, the default value of *rootDir* is `./`, i.e. the current directory.
+
+Note: *rootDir* should be the *target* directory containing the output of your build process, not the *source* directory containing the original files. For example, if your source files are in *app/*, and your build process outputs into *dist/*, then you should specify the *dist/* directory.
+
+### Options
+
+The *deploy* command takes the following options via both the CLI and the module:
+
+- `-m, --message message` or `message: 'message'` - the message for the commit to the *gh-pages* branch
+
+The *deploy* command takes the following options via the module only:
+
+- `cloneDir: 'dir'` - the directory into which Oghliner will create a temporary clone of the repository while deploying the app (default is implementation detail). This is mostly useful internally, for implementation of the CLI.
+- `fileGlobs: ['glob', …]` - a comma-separated list of globs identifying the files to offline (default: `**/*`). The globs are matched inside *rootDir*.
+- `remote: 'remote'` - the Git remote to which to push the *gh-pages* branch (default: `origin`).
+
+## Configure
+
+The *configure* command configures Travis to automatically deploy an app to GitHub Pages when you push to its *master* branch.
+
+To use it, invoke `oghliner configure` within your local working directory:
+
+```
+oghliner configure
+```
+
+Oghliner will create a GitHub token that authorizes Travis to push changes to your repository, then configure Travis to use the token to deploy changes.
+
+```
+Configuring Travis to auto-deploy to GitHub Pages…
+
+Your repository has a single remote, origin.
+Ok, I'll configure Travis to auto-deploy the origin remote (mykmelez/offline-app).
+
+To check the status of your repository in Travis and authorize Travis to push
+to it, I'll create GitHub personal access tokens, for which I need your GitHub
+username and password (and two-factor authentication code, if appropriate).
+
+ℹ For more information about GitHub personal access tokens, see:
+    https://github.com/settings/tokens
+
+Username: mykmelez
+Password:
+
+× Checking credentials… error!
+
+You're using two-factor authentication with GitHub.
+Please enter the code provided by your authentication software.
+
+Auth Code: 123456
+
+✓ Checking credentials… done!
+✓ Creating temporary GitHub token for getting Travis token… done!
+✓ Getting Travis token… done!
+✓ Deleting temporary GitHub token for getting Travis token… done!
+✓ Creating permanent GitHub token for Travis to push to the repository… done!
+✓ Checking the status of your repository in Travis… done!
+✓ I didn't find your repository in Travis; syncing Travis with GitHub… done!
+✓ Checking the status of your repository in Travis… done!
+✓ Your repository isn't active in Travis yet; activating it… done!
+✓ Encrypting permanent GitHub token… done!
+✓ Writing configuration to .travis.yml file… done!
+
+⚠ You didn't already have a .travis.yml file, so I created one for you.
+  For more information about the file, see:
+    http://docs.travis-ci.com/user/customizing-the-build/
+
+You're ready to auto-deploy using Travis!  Just commit the changes
+in .travis.yml and push the commit to the origin/master branch:
+
+git add .travis.yml
+git commit -m"configure Travis to auto-deploy to GitHub Pages" .travis.yml
+git push origin master
+
+Then visit https://travis-ci.org/mykmelez/offline-app/builds to see the build status.
+```
+
+After configuring the repository, add and commit the changes to *.travis.yml* and push the *master* branch to the *origin* remote on GitHub to make Travis build and auto-deploy your app:
+
+```
+git add .travis.yml
+git commit -m"configure Travis to auto-deploy to GitHub Pages" .travis.yml
+git push origin master
+```
+
+You can see the status of a build/deployment at `https://travis-ci.org/USERNAME/REPOSITORY/builds`. For example, the status of builds for https://github.com/mykmelez/eggtimer/ is at https://travis-ci.org/mykmelez/eggtimer/builds.
+
+Once configured, Travis deploys successful builds via `gulp deploy`. You can change the deploy command by editing your .travis.yml file.
+
+Note: Oghliner needs your GitHub credentials to create the token, and the token gives Travis limited access to your GitHub account. Specifically, the token provides the *public_repo* [scope](https://developer.github.com/v3/oauth/#scopes), which gives Travis "read/write access to code, commit statuses, collaborators, and deployment statuses for public repositories and organizations." For more information about personal access tokens, see [Creating an access token for command-line use](https://help.github.com/articles/creating-an-access-token-for-command-line-use/).
+
+## Build Process Integration
+
+You can integrate Oghliner into your Node-based build process via its module interface. This is particularly helpful for the *offline* and *deploy* commands, which you'll call each time you change your app and rebuild it.
+
+To do so, first install Oghliner locally and save it to your *dependencies*:
+
+```
+npm install --save oghliner
+```
+
+Then require the module in your build script and call its *offline* function, passing *options* to configure its behavior. For example, if you use Gulp to build your app, you could add code like this to your gulpfile.js:
 
 ```js
 var oghliner = require('oghliner');
@@ -72,46 +332,18 @@ gulp.task('deploy', function(callback) {
 });
 ```
 
-The *oghliner.offline* task takes a *config* object and a *callback*. The properties of the *config* object are:
-- *rootDir*: the directory to offline (default: `./`);
-- *fileGlobs*: an array of file globs to offline (default: `['**/*']`). The files specified by *fileGlobs* are matched inside *rootDir*.
-- *importScripts*: an array of additional scripts to import into offline-worker.js (default: `[]`). This is useful, for example, when you want to use the [Push API](https://developer.mozilla.org/en-US/docs/Web/API/Push_API).
+Then you could invoke `gulp offline && gulp deploy` to offline and deploy your app.
 
-*oghliner.deploy* deploys your files to GitHub Pages. It takes a *config* object and a *callback*. The properties of the *config* object are:
+## Gulp Integration
 
-- *rootDir*: the directory to deploy (default: `./`).
+If you used Oghliner to bootstrap your app, then it already has a gulpfile.js with tasks for building, offlining, and deploying your app.  To use it, install Gulp globally:
 
-Finally, in order for offline-worker.js to be evaluated, you need to load the offline manager script in your app by copying it to the location of your other scripts. To do this, use the *integrate* command (or *oghliner.integrate* function):
-
-```bash
-oghliner integrate path/to/your/scripts/
+```
+npm install --global gulp
 ```
 
-Automatic Deployment Via Travis
--------------------------------
+Then invoke `gulp` to build and offline your app and `gulp deploy` to deploy it:
 
-Oghliner can configure a repository to automatically deploy to GitHub Pages whenever you push to its *master* branch. Auto-deploy uses [Travis CI](https://travis-ci.org/), a continuous integration service. Oghliner takes care of most of the steps to configure your repository to auto-deploy via Travis.
-
-If you bootstrapped your app from the template, your repository already has a suitable Travis configuration file (.travis.yml) and a *configure* task in gulpfile.js. Just `gulp configure` to configure your repository.
-
-If you integrated the tool into an existing app, `npm install -g oghliner && oghliner configure` to configure your repository.
-
-Oghliner will prompt you for your GitHub credentials in order to create a token that authorizes Travis to push changes to your repository. The token will give Travis limited access to your GitHub account. Specifically: it will have the *public_repo* [scope](https://developer.github.com/v3/oauth/#scopes), which gives it "read/write access to code, commit statuses, collaborators, and deployment statuses for public repositories and organizations."
-
-After configuring the repository, add and commit the changes to *.travis.yml* and push the *master* branch to the *origin* remote on GitHub to make Travis build and auto-deploy your app:
-
-```bash
-> git commit -m"configure Travis to auto-deploy to GitHub Pages" .travis.yml
-> git push origin master
 ```
-
-You can see the status of a build/deployment at `https://travis-ci.org/*your-GitHub-username*/*your-repository-name*/builds`. For example, the status of builds for https://github.com/mykmelez/eggtimer/ is at https://travis-ci.org/mykmelez/eggtimer/builds.
-
-If the build was successful, Travis will deploy the site via `gulp deploy`. Expand the log entry to see details about the deployment:
-
-```bash
-$ [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ "${TRAVIS_BRANCH}" = "master" ] && gulp deploy
-[23:34:13] Using gulpfile ~/build/mykmelez/eggtimer/gulpfile.js
-[23:34:13] Starting 'deploy'...
-[23:34:15] Finished 'deploy' after 1.96 s
+gulp && gulp deploy
 ```

--- a/README.md
+++ b/README.md
@@ -342,8 +342,8 @@ If you used Oghliner to bootstrap your app, then it already has a gulpfile.js wi
 npm install --global gulp
 ```
 
-Then invoke `gulp` to build and offline your app and `gulp deploy` to deploy it:
+Then invoke `gulp build && gulp offline && gulp deploy` to build, offline, and deploy your app:
 
 ```
-gulp && gulp deploy
+gulp build && gulp offline && gulp deploy
 ```

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -546,7 +546,7 @@ module.exports = function() {
           language: 'node_js',
           node_js: [ '0.12' ],
           install: 'npm install',
-          script: 'gulp',
+          script: 'gulp build && gulp offline',
         };
       } else {
         throw err;

--- a/test/testConfigure.js
+++ b/test/testConfigure.js
@@ -73,7 +73,7 @@ describe('Configure', function() {
     expect(travisYml.language).to.equal('node_js');
     expect(travisYml.node_js).to.deep.equal(['0.12']);
     expect(travisYml.install).to.equal('npm install');
-    expect(travisYml.script).to.equal('gulp');
+    expect(travisYml.script).to.equal('gulp build && gulp offline');
     expect(travisYml).to.include.keys('env');
     expect(travisYml.env).to.include.keys('global');
     expect(travisYml.env.global).to.have.length(1);

--- a/test/testLiveAsTemplate.js
+++ b/test/testLiveAsTemplate.js
@@ -70,7 +70,8 @@ describe('CLI interface, oghliner as a template', function() {
     })
     .then(liveUtils.spawn.bind(null, 'git', ['add', '*']))
     .then(liveUtils.spawn.bind(null, 'git', ['commit', '-m', 'First commit']))
-    .then(liveUtils.spawn.bind(null, path.join('node_modules', '.bin', 'gulp'), []))
+    .then(liveUtils.spawn.bind(null, path.join('node_modules', '.bin', 'gulp'), ['build']))
+    .then(liveUtils.spawn.bind(null, path.join('node_modules', '.bin', 'gulp'), ['offline']))
     .then(function() {
       assert.doesNotThrow(fse.statSync.bind(fse, 'dist'));
     })
@@ -99,7 +100,7 @@ describe('CLI interface, oghliner as a template', function() {
       expect(travisYml.language).to.equal('node_js');
       expect(travisYml.node_js).to.deep.equal(['0.12']);
       expect(travisYml.install).to.equal('npm install');
-      expect(travisYml.script).to.equal('gulp');
+      expect(travisYml.script).to.equal('gulp build && gulp offline');
       expect(travisYml).to.include.keys('env');
       expect(travisYml.env).to.include.keys('global');
       expect(travisYml.env.global).to.have.length(1);

--- a/test/testLiveAsTool.js
+++ b/test/testLiveAsTool.js
@@ -80,7 +80,7 @@ describe('CLI interface, oghliner as a tool', function() {
       expect(travisYml.language).to.equal('node_js');
       expect(travisYml.node_js).to.deep.equal(['0.12']);
       expect(travisYml.install).to.equal('npm install');
-      expect(travisYml.script).to.equal('gulp');
+      expect(travisYml.script).to.equal('gulp build && gulp offline');
       expect(travisYml).to.include.keys('env');
       expect(travisYml.env).to.include.keys('global');
       expect(travisYml.env.global).to.have.length(1);


### PR DESCRIPTION
I'm not a fan of the way we obscure the build steps behind the _default_ task run by Gulp when you invoke it without arguments. If there were many steps, then I'd understand, but there are only two: _build_ and _offline_. We should run these two steps explicitly, and document them accordingly, so it's clear to developers how to build and offline a bootstrapped app.

This is based on #197, since it edits the README reference to gulp, and the README is being rewritten by that pull.
