### PR TITLE
set user-agent for Travis requests (fixes #215)

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -44,7 +44,12 @@ var ghslug = promisify(require('github-slug'));
 // nock.recorder.rec();
 
 var Travis = require('travis-ci');
-var travis = new Travis({ version: '2.0.0' });
+var travis = new Travis({
+  version: '2.0.0',
+  headers: {
+    'user-agent': 'Oghliner'
+  },
+});
 
 var GitHub = require('github');
 var github = new GitHub({

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "sw-precache": "^2.0.0",
     "temp": "^0.8.3",
     "through2": "^2.0.0",
-    "travis-ci": "^2.0.3",
+    "travis-ci": "https://github.com/mykmelez/node-travis-ci/tarball/e35375de8b06bbe7209b5dfe94f816737002e928",
     "travis-encrypt": "^1.1.2",
     "write-yaml": "^0.2.1"
   },


### PR DESCRIPTION
This fixes #215 by setting the User-Agent header for Travis requests to `Oghliner`. It depends on https://github.com/mykmelez/node-travis-ci/tree/custom-headers, for which I've requested https://github.com/pwmckenna/node-travis-ci/pull/6 and filed followup issue #218 to switch back to the npm version of travis-ci once that branch is merged and the version in npm is updated.
