### PR TITLE
Adding in directoryIndexes support for replacing filenames with dir c…

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ The *offline* command takes the following options:
 
 - `--file-globs glob,…` or `fileGlobs: ['glob', …]` - a comma-separated list of globs identifying the files to offline (default: `**/*`). The globs are matched inside *rootDir*.
 - `--import-scripts script,…` or `importScripts: ['script', …]` - a comma-separated list of additional scripts to evaluate in the service worker (no default value). This is useful, for example, when you want to use the [Push API](https://developer.mozilla.org/en-US/docs/Web/API/Push_API).
+- `--directory-indexes index.html,…` or `directoryIndexes: ['index.html', …]` - a comma-separated list of file names that will be replaced to be served as a directory. (default: `index.html`) This fixes links to `'path/name/'` that don't have the file: `'path/name/index.html'`
 
 ## Deploy
 

--- a/cli.js
+++ b/cli.js
@@ -94,11 +94,13 @@ program
   .description('offline the files in the directory by generating offline-worker.js script')
   .option('--file-globs [fileGlobs]', 'a comma-separated list of file globs to offline (default: \'**/*\')', '**/*')
   .option('--import-scripts <importScripts>', 'a comma-separated list of additional scripts to import into offline-worker.js')
+  .option('--directory-indexes <directoryIndexes>', 'change files to be a directory only')
   .action(function(dir, options) {
     offline({
       rootDir: dir,
       fileGlobs: options.fileGlobs ? options.fileGlobs.split(',') : null,
       importScripts: options.importScripts ? options.importScripts.split(',') : null,
+      directoryIndexes: options.directoryIndexes ? options.directoryIndexes.split(',') : null,
     })
     .catch(function(err) {
       process.stderr.write(chalk.red.bold(err) + '\n');

--- a/lib/offline.js
+++ b/lib/offline.js
@@ -29,6 +29,7 @@ var gulp = require('gulp');
 var ghslug = promisify(require('github-slug'));
 var prettyBytes = require('pretty-bytes');
 var gzipSize = require('gzip-size');
+var escapeStringRegexp = require('escape-string-regexp');
 
 module.exports = function(config) {
   return new Promise(function(resolve, reject) {
@@ -51,6 +52,8 @@ module.exports = function(config) {
 
     var fileGlobs = config.fileGlobs || ['**/*'];
     var importScripts = config.importScripts || [];
+    var directoryIndexes = config.directoryIndexes || ['index.html'];
+    var directoryIndexMatch = new RegExp('/(' + directoryIndexes.map(escapeStringRegexp).join('|') + ')$');
 
     // Remove the existing service worker, if any, so the worker doesn't include
     // itself in the list of files to cache.
@@ -110,6 +113,15 @@ module.exports = function(config) {
       }, {}));
     }
 
+    function getPathName(filepath, rootDir) {
+       filepath = filepath.replace(directoryIndexMatch, '/');
+
+       return filepath.replace(rootDir, function (match, offset) {
+         // The root must be the worker's directory
+         return offset === 0 ? './' : match;
+       });
+    }
+
     function getFilesAndHashes(files, rootDir, sizeWhiteList) {
       var totalSize = 0;
       var totalGzipSize = 0;
@@ -119,19 +131,30 @@ module.exports = function(config) {
         var data = fs.readFileSync(filepath);
         totalGzipSize += gzipSize.sync(data);
         var hash = getHash(data);
-        process.stdout.write(chalk.green.bold('✓ ') + 'Caching ' + filepath + ' (' + prettyBytes(size) + ')\n');
+        var path = getPathName(filepath, rootDir);
+        var rootMatch = new RegExp('^' + rootDir);
+        var pathAtString = '';
+        if (filepath.replace(rootMatch, './') !== path) {
+          pathAtString = ' at path ' + path;
+        }
+
+        process.stdout.write(chalk.green.bold('✓ ') + 'Caching ' + filepath + pathAtString + ' (' + prettyBytes(size) + ')\n');
         return {
-          path: filepath.replace(rootDir, function (match, offset) {
-            // The root must be the worker's directory
-            return offset === 0 ? './' : match;
-          }),
+          path: path,
           hash: hash,
         };
       });
 
       process.stdout.write('Total cache size is ' + prettyBytes(totalSize) + ' (' + prettyBytes(totalGzipSize) + ' if served with gzip) for ' + files.length + ' files.\n');
 
-      return filesAndHashes;
+      filesAndHashes.unshift({
+        path: './'
+      }); // cache always the current root to make the default page available
+
+      // Remove duplicates from file list
+      return filesAndHashes.filter(function(fileName, index) {
+        return filesAndHashes.indexOf(fileName) === index;
+      });
     }
 
     function checkImports(imports, rootDir) {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "change-case": "^2.3.0",
     "cli": "^0.11.1",
     "commander": "^2.8.1",
+    "escape-string-regexp": "^1.0.3",
     "fs-extra": "^0.26.0",
     "gh-pages": "https://github.com/marco-c/gh-pages/tarball/817ee16441d72a0c1d33ce109cddf9c1963991d8",
     "git-list-remotes": "^1.0.0",

--- a/templates/app/offline-worker.js
+++ b/templates/app/offline-worker.js
@@ -44,7 +44,6 @@
 
     // This is a list of resources that will be cached.
     RESOURCES: [
-      './', // cache always the current root to make the default page available
 <% resources.forEach(function (pathAndHash) {
 %>      '<%- pathAndHash.path %>', // <%- pathAndHash.hash %>
 <% }); %>

--- a/test/testOffline.js
+++ b/test/testOffline.js
@@ -257,6 +257,31 @@ describe('Offline', function() {
     });
   });
 
+  it('should cache directoryIndexes as dirs', function() {
+    var rootDir = temp.mkdirSync('oghliner');
+    var dir = path.join(rootDir, 'dist');
+    fs.mkdirSync(dir);
+    var subDir = path.join(dir, 'subdir');
+    fs.mkdirSync(subDir);
+
+    fs.writeFileSync(path.join(subDir, 'test_file_1.js'), 'test_file_1');
+    fs.writeFileSync(path.join(subDir, 'test_file_2.js'), 'test_file_2');
+    fs.writeFileSync(path.join(subDir, 'test_file_3.js'), 'test_file_3');
+
+    process.chdir(rootDir);
+
+    return offline({
+      rootDir: dir,
+      directoryIndexes: ['test_file_1.js']
+    }).then(function() {
+      var content = fs.readFileSync(path.join(dir, 'offline-worker.js'), 'utf8');
+      assert.notEqual(content.indexOf('\'./\''), -1, 'Must have a directory in the output');
+      assert.equal(content.indexOf('test_file_1.js'), -1, 'Must have replaced the file name');
+      assert.notEqual(content.indexOf('test_file_2.js'), -1);
+      assert.notEqual(content.indexOf('test_file_3.js'), -1);
+    });
+  });
+
   it('should cache large files', function() {
     var rootDir = temp.mkdirSync('oghliner');
     var dir = path.join(rootDir, 'dist');


### PR DESCRIPTION
…aching

This change is to add support for directories to be supported instead of the file that they are stored at in the file structure.

Currently in Chrome this causes an issue as it seems Firefox makes the assumption that the index.html resolves to the directory.
This can be seen on https://www.cyber-ami.com/how-we-help/ where chrome caches: https://www.cyber-ami.com/how-we-help/index.html (This was even the case when we were 301 redirecting the html file to the directory).

Either way it seems better form to cache the directory and have a setting to control it.

Let me know if there are any issues or queries thank you.
