### PR TITLE
Adding in ability to specify offline directory.

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ The *offline* command takes the following options:
 
 - `--file-globs glob,…` or `fileGlobs: ['glob', …]` - a comma-separated list of globs identifying the files to offline (default: `**/*`). The globs are matched inside *rootDir*.
 - `--import-scripts script,…` or `importScripts: ['script', …]` - a comma-separated list of additional scripts to evaluate in the service worker (no default value). This is useful, for example, when you want to use the [Push API](https://developer.mozilla.org/en-US/docs/Web/API/Push_API).
+- `--prefixResourceDirectory` or `prefixResourceDirectory: '/sw'` - a path prefix which is used by the service woker when it fetches the resources on the client. (default: `''`) This is useful to provide different content for offline users.
 
 ## Deploy
 

--- a/lib/offline.js
+++ b/lib/offline.js
@@ -51,6 +51,7 @@ module.exports = function(config) {
 
     var fileGlobs = config.fileGlobs || ['**/*'];
     var importScripts = config.importScripts || [];
+    var prefixResourceDirectory = config.prefixResourceDirectory || '';
 
     // Remove the existing service worker, if any, so the worker doesn't include
     // itself in the list of files to cache.
@@ -86,6 +87,7 @@ module.exports = function(config) {
         cacheId: cacheId,
         cacheVersion: getHashOfHashes(pluckHashes(filesAndHashes)),
         resources: filesAndHashes,
+        prefixResourceDirectory: prefixResourceDirectory,
         importScripts: importScripts,
       };
 

--- a/templates/app/offline-worker.js
+++ b/templates/app/offline-worker.js
@@ -50,6 +50,9 @@
 <% }); %>
     ],
 
+    // This is where the service worker will call for resources, allowing for a smaller service worker version of the same file.
+    prefixResourceDirectory: '<%= prefixResourceDirectory %>',
+
     // Adds the resources to the cache controlled by this worker.
     cacheResources: function () {
       var now = Date.now();
@@ -61,6 +64,9 @@
           var url = new URL(resource, baseUrl);
           var bustParameter = (url.search ? '&' : '') + '__bust=' + now;
           var bustedUrl = new URL(url.toString());
+          if (this.prefixResourceDirectory) {
+            bustedUrl.pathname = this.prefixResourceDirectory + bustedUrl.pathname;
+          }
           bustedUrl.search += bustParameter;
 
           // But cache the response for the original request

--- a/test/testOffline.js
+++ b/test/testOffline.js
@@ -53,6 +53,18 @@ describe('Offline', function() {
 
     return offline({
       rootDir: dir,
+      prefixResourceDirectory: '/sw'
+    }).then(function() {
+      var content = fs.readFileSync(path.join(dir, 'offline-worker.js'), 'utf8');
+      assert.notEqual(content.indexOf('\'/sw\','), -1);
+    });
+  });
+
+  it('should create offline-worker.js in the destination directory', function() {
+    var dir = temp.mkdirSync('oghliner');
+
+    return offline({
+      rootDir: dir,
     }).then(function() {
       assert.doesNotThrow(fs.accessSync.bind(fs, path.join(dir, 'offline-worker.js')));
     });


### PR DESCRIPTION
This needs further review (it's late here and I wanted to push so I don't forget it) however I thought @mykmelez you might be interested in looking at it.

The idea is to add support for the service worker to cache all the `RESOURCES` files with a prefix. This is useful to filter out all the code that browsers that don't support service worker need/have.

This is a similar concept we are using on our site but will also allow for neater stylesheets also - the idea was to reduce that initial resources load down as much as possible to get the finite functional set to read the site. This resource files actually cause network thrashing on mobile devices which will mostly not be an issue with http/2 however changing content to be lighter should always benefit the user.
