### PR TITLE
Run tests using 'stable' version of Node.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
   - '0.12'
-  - '4'
+  - 'stable'
 addons:
   apt:
     sources:


### PR DESCRIPTION
This way we notice when something breaks on new Node.js releases.
