### PR TITLE
Update pretty-bytes dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "gulp-template": "^3.0.0",
     "gzip-size": "^3.0.0",
     "mozilla-tabzilla": "^0.5.1",
-    "pretty-bytes": "^2.0.1",
+    "pretty-bytes": "^2.0.1 || ^3.0.0",
     "promisified-promptly": "^1.0.0",
     "promisify-node": "^0.2.1 || ^0.3.0",
     "read-yaml": "^1.0.0",


### PR DESCRIPTION
There's basically no difference between pretty-bytes 2.0 and 3.0 (the main difference is that it's smaller, given that the CLI module has been separated).
