### PR TITLE
Test all Node.js LTS releases and the stable release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
   - '0.12'
+  - '4'
   - 'stable'
 addons:
   apt:


### PR DESCRIPTION
I'd run tests using all the LTS releases (currently 0.12 and 4, 0.12 will be dropped around April 2016) and the stable release.
In total, there will always be three Node.js versions tested (two LTSes and one stable: https://nodejs.org/en/blog/community/node-v5/).
