### PR TITLE
remove sw-precache dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "promisified-promptly": "^1.0.0",
     "promisify-node": "^0.2.1 || ^0.3.0",
     "read-yaml": "^1.0.0",
-    "sw-precache": "^2.0.0",
     "temp": "^0.8.3",
     "through2": "^2.0.0",
     "travis-ci": "^2.1.0",


### PR DESCRIPTION
Oghliner no longer depends on sw-precache.
